### PR TITLE
`style` and `transform` prop for `Path2D`

### DIFF
--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -1,55 +1,62 @@
-import { Component, createEffect, createSignal, JSX } from 'solid-js'
-import { Arc, Canvas, createClock, Group, Rectangle } from 'src'
-import { Vector } from 'src/types'
-import { SingleOrArray } from 'src/utils/typehelpers'
-
-const Arm = (props: {
-  position?: Vector
-  rotation?: number
-  length?: number
-  children?: SingleOrArray<JSX.Element>
-}) => {
-  return (
-    <Group
-      position={{ x: props.position?.x ?? 0, y: (props.position?.y ?? 0) + 5 }}
-      rotation={props.rotation ?? 0}
-    >
-      <Rectangle
-        position={{ x: 0, y: -5 }}
-        dimensions={{ width: props.length ?? 100, height: 10 }}
-        fill="white"
-      >
-        <Arc position={{ x: -5, y: -5 }} fill="black" />
-        <Group position={{ x: props.length ?? 100, y: 0 }}>
-          {props.children}
-        </Group>
-      </Rectangle>
-    </Group>
-  )
-}
+import { Component, For } from 'solid-js'
+import { Canvas, createClock, Rectangle } from 'src'
+import { Drag } from 'src/controllers/Drag'
 
 const App: Component = () => {
-  /* const [time, setTime] = createSignal(180)
-  setInterval(() => setTime(t => t + 1), 100) */
+  const randoms = new Array(100).fill('').map(v => ({
+    x: Math.random() * (window.innerWidth + 200),
+    y: Math.random() * (window.innerHeight + 200),
+  }))
 
   const clock = createClock()
   clock.start()
 
-  // createEffect(() => console.log('time', time()))
-
   return (
     <>
-      <Canvas style={{ width: '100%', height: '100%' }} alpha draggable>
-        <Arm rotation={180 - clock.clock()} position={{ x: 400, y: 300 }}>
-          <Arm rotation={180 - clock.clock()}>
-            <Arm rotation={180 - clock.clock()} />
-          </Arm>
-        </Arm>
-        <Arm rotation={clock.clock()} position={{ x: 850, y: 300 }}>
-          <Arm rotation={clock.clock()}>
-            <Arm rotation={clock.clock()} />
-          </Arm>
-        </Arm>
+      <Canvas
+        // clock={clock.clock()}
+        style={{ width: '100vw', height: '100vh' }}
+        alpha
+        stats
+        draggable
+      >
+        <For
+          each={new Array(400).fill('').map((v, i) => ({
+            transform: {
+              position: {
+                x: Math.random() * (window.innerWidth + 200) - 100,
+                y: Math.random() * (window.innerHeight + 200) - 100,
+              },
+              skew: {
+                y: Math.random() * 90,
+              },
+            },
+            style: {
+              fill: {
+                r: Math.random() * 215,
+                g: Math.random() * 215,
+                b: Math.random() * 215,
+              },
+            },
+          }))}
+        >
+          {(data, i) => (
+            <Rectangle
+              transform={data.transform}
+              style={{
+                ...data.style,
+                dimensions: { width: 100, height: 100 },
+                lineWidth: 20,
+                stroke: undefined,
+                composite: 'soft-light',
+                '&:hover': {
+                  fill: 'black',
+                },
+              }}
+              controllers={[Drag()]}
+            />
+          )}
+        </For>
       </Canvas>
     </>
   )

--- a/dev/pages/Arms.tsx
+++ b/dev/pages/Arms.tsx
@@ -9,20 +9,47 @@ const Arm = (props: {
   length?: number
   children?: SingleOrArray<JSX.Element>
 }) => {
+  const [fill, setFill] = createSignal('black')
+  setTimeout(() => setFill('white'), 1000)
+
   return (
     <Group
-      position={{ x: props.position?.x ?? 0, y: (props.position?.y ?? 0) + 5 }}
-      rotation={props.rotation ?? 0}
+      transform={{
+        position: {
+          x: props.position?.x ?? 0,
+          y: (props.position?.y ?? 0) + 5,
+        },
+        rotation: props.rotation ?? 0,
+      }}
     >
       <Rectangle
-        position={{ x: 0, y: -5 }}
-        dimensions={{ width: props.length ?? 100, height: 10 }}
-        fill="white"
+        transform={{
+          position: { x: 0, y: -5 },
+        }}
+        style={{
+          dimensions: { width: props.length ?? 100, height: 10 },
+          fill: 'white',
+        }}
       >
-        <Group position={{ x: props.length ?? 100, y: 0 }}>
+        <Group
+          transform={{
+            position: { x: props.length ?? 100, y: 0 },
+          }}
+        >
           {props.children}
         </Group>
-        <Arc position={{ x: -5, y: -5 }} fill="black" />
+        <Arc
+          transform={{
+            position: { x: -10, y: -5 },
+          }}
+          style={{
+            // fill: 'black',
+            get fill() {
+              return fill()
+            },
+            radius: 10,
+          }}
+        />
       </Rectangle>
     </Group>
   )
@@ -45,11 +72,11 @@ const App: Component = () => {
             <Arm rotation={180 - clock.clock()} />
           </Arm>
         </Arm>
-        {/* <Arm rotation={clock.clock()} position={{ x: 850, y: 300 }}>
+        <Arm rotation={clock.clock()} position={{ x: 850, y: 300 }}>
           <Arm rotation={clock.clock()}>
             <Arm rotation={clock.clock()} />
           </Arm>
-        </Arm> */}
+        </Arm>
       </Canvas>
     </>
   )

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   "dependencies": {
     "@solid-primitives/jsx-tokenizer": "^1.0.0",
     "@solid-primitives/memo": "^1.2.3",
+    "@solid-primitives/scheduled": "^1.3.2",
     "vite": "^4.2.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@solid-primitives/jsx-tokenizer': ^1.0.0
   '@solid-primitives/memo': ^1.2.3
+  '@solid-primitives/scheduled': ^1.3.2
   concurrently: ^7.6.0
   esbuild: ^0.17.4
   esbuild-plugin-solid: ^0.5.0
@@ -20,6 +21,7 @@ specifiers:
 dependencies:
   '@solid-primitives/jsx-tokenizer': 1.0.0_solid-js@1.6.16
   '@solid-primitives/memo': 1.2.3_solid-js@1.6.16
+  '@solid-primitives/scheduled': 1.3.2_solid-js@1.6.16
   vite: 4.2.1
 
 devDependencies:
@@ -1951,7 +1953,7 @@ packages:
       '@solid-primitives/event-listener': 2.2.8_solid-js@1.6.16
       '@solid-primitives/keyboard': 1.0.10_solid-js@1.6.16
       '@solid-primitives/platform': 0.0.103_solid-js@1.6.16
-      '@solid-primitives/scheduled': 1.3.1_solid-js@1.6.16
+      '@solid-primitives/scheduled': 1.3.2_solid-js@1.6.16
       '@solid-primitives/utils': 5.5.0_solid-js@1.6.16
       solid-js: 1.6.16
       type-fest: 3.6.1
@@ -1967,7 +1969,7 @@ packages:
       '@solid-primitives/media': 2.1.4_solid-js@1.6.16
       '@solid-primitives/refs': 0.3.7_solid-js@1.6.16
       '@solid-primitives/rootless': 1.3.0_solid-js@1.6.16
-      '@solid-primitives/scheduled': 1.3.1_solid-js@1.6.16
+      '@solid-primitives/scheduled': 1.3.2_solid-js@1.6.16
       '@solid-primitives/styles': 0.0.101_solid-js@1.6.16
       '@solid-primitives/utils': 5.5.0_solid-js@1.6.16
       solid-js: 1.6.16
@@ -2102,21 +2104,12 @@ packages:
       solid-js: 1.6.16
     dev: true
 
-  /@solid-primitives/scheduled/1.3.1_solid-js@1.6.16:
-    resolution: {integrity: sha512-3tEyYAoGteeSMjXh1HfX1MteU9PpEP8cq0w26ffa3xScaN/EklonZZiy1ajJJuen/WQ5f2zZ3WmHCMnLMbURow==}
-    peerDependencies:
-      solid-js: ^1.6.0
-    dependencies:
-      solid-js: 1.6.16
-    dev: true
-
   /@solid-primitives/scheduled/1.3.2_solid-js@1.6.16:
     resolution: {integrity: sha512-2rDCyYNjI9zBqpdmJG8sN8h90gbe2hSqRdj1OMmKp3qEbKVCrXXswLmrbBuNBi/uow6f8AHR9uheb7LWQ3ojcw==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
       solid-js: 1.6.16
-    dev: false
 
   /@solid-primitives/styles/0.0.101_solid-js@1.6.16:
     resolution: {integrity: sha512-tHkeUMntlS/w+/zDzXJv82hhMy3J3q7tVV3ZTbahRo0hZienAM8ZJrCYZNK/fu2px8NHVSZFRufxv9qhIclPTw==}

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -185,7 +185,6 @@ export const Canvas: Component<{
     })
 
     ctx.save()
-    ctx.beginPath()
     if (typeof props.feedback === 'number' || props.feedback) {
       if (typeof props.feedback === 'function') props.feedback(ctx)
       else if (typeof props.feedback === 'object') {
@@ -220,10 +219,8 @@ export const Canvas: Component<{
     ctx.restore()
 
     for (const token of tokens()) {
-      ctx.save()
       if ('debug' in token.data && props.debug) token.data.debug(ctx)
       if ('render' in token.data) token.data.render(ctx)
-      ctx.restore()
     }
 
     if (props.fill) {

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -36,7 +36,7 @@ export const Canvas: Component<{
   children: JSX.Element
   style?: JSX.CSSProperties
   fill?: Color
-  origin?: {
+  transform?: {
     position: Vector
     skew: Vector
     rotation: number
@@ -114,7 +114,7 @@ export const Canvas: Component<{
 
   const frameQueue = new Set<(args: { clock: number }) => void>()
 
-  const matrix = createMatrix(props)
+  const matrix = createMatrix(() => props)
 
   const tokens = resolveTokens(
     parser,
@@ -362,10 +362,10 @@ export const Canvas: Component<{
 
   onMount(() => {
     const updateDimensions = () => {
-      const { width, height } = document.body.getBoundingClientRect()
+      // const { width, height } = document.body.getBoundingClientRect()
       setCanvasDimensions({
-        width,
-        height,
+        width: window.innerWidth,
+        height: window.innerHeight,
       })
     }
 

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -219,11 +219,10 @@ export const Canvas: Component<{
 
     ctx.restore()
 
-    let data
-    for ({ data } of tokens()) {
+    for (const token of tokens()) {
       ctx.save()
-      if ('debug' in data && props.debug) data.debug(ctx)
-      if ('render' in data) data.render(ctx)
+      if ('debug' in token.data && props.debug) token.data.debug(ctx)
+      if ('render' in token.data) token.data.render(ctx)
       ctx.restore()
     }
 

--- a/src/components/Object2D/Group.tsx
+++ b/src/components/Object2D/Group.tsx
@@ -15,9 +15,9 @@ export type GroupProps = {
   clip?: Accessor<SingleOrArray<JSX.Element>>
   position?: Vector
   controllers?: ((
-    props: Accessor<ResolvedShape2DProps>,
+    props: Accessor<ResolvedShape2DProps<any>>,
     events: RegisterControllerEvents,
-  ) => Accessor<ResolvedShape2DProps>)[]
+  ) => Accessor<ResolvedShape2DProps<any>>)[]
 }
 
 /**

--- a/src/components/Object2D/Shape2D/Image.ts
+++ b/src/components/Object2D/Shape2D/Image.ts
@@ -32,7 +32,7 @@ const Image = createToken(
     const image = resolveImageSource(() => props.image)
     const [context, setContext] = createSignal<InternalContextType>()
 
-    const matrix = createMatrix(props, context())
+    const matrix = createMatrix(() => props, context())
 
     return createShape2D({
       props,

--- a/src/components/Object2D/Shape2D/Path2D/Arc.tsx
+++ b/src/components/Object2D/Shape2D/Path2D/Arc.tsx
@@ -5,11 +5,13 @@ import { Shape2DProps } from 'src/types'
 import { createPath2D } from '../../../../utils/createPath2D'
 
 type ArcProps = {
-  close?: boolean
-  radius?: number
-  angle?: {
-    start: number
-    end: number
+  style: {
+    close?: boolean
+    radius?: number
+    angle?: {
+      start: number
+      end: number
+    }
   }
 }
 
@@ -22,18 +24,20 @@ const Arc = createToken(parser, (props: Shape2DProps<ArcProps> & ArcProps) =>
     id: 'Arc',
     props,
     defaultProps: {
-      close: false,
-      radius: 10,
-      angle: { start: 0, end: 2 * Math.PI },
+      style: {
+        angle: { start: 0, end: 2 * Math.PI },
+        close: false,
+        radius: 10,
+      },
     },
     path: props => {
       const path = new Path2D()
       path.arc(
-        props.radius,
-        props.radius,
-        props.radius,
-        props.angle.start,
-        props.angle.end,
+        props.style.radius,
+        props.style.radius,
+        props.style.radius,
+        props.style.angle.start,
+        props.style.angle.end,
       )
       return path
     },
@@ -43,16 +47,16 @@ const Arc = createToken(parser, (props: Shape2DProps<ArcProps> & ArcProps) =>
         y: 0,
       },
       {
-        x: props.radius * 2,
+        x: props.style.radius * 2,
         y: 0,
       },
       {
-        x: props.radius * 2,
-        y: props.radius * 2,
+        x: props.style.radius * 2,
+        y: props.style.radius * 2,
       },
       {
         x: 0,
-        y: props.radius * 2,
+        y: props.style.radius * 2,
       },
     ],
   }),

--- a/src/components/Object2D/Shape2D/Path2D/Rectangle.tsx
+++ b/src/components/Object2D/Shape2D/Path2D/Rectangle.tsx
@@ -5,13 +5,15 @@ import { Dimensions, Shape2DProps } from 'src/types'
 import { createPath2D } from '../../../../utils/createPath2D'
 
 export type RectangleProps = {
-  dimensions?: Dimensions
-  rounded?:
-    | false
-    | number
-    | [all: number]
-    | [topLeftAndBottomRight: number, topRightAndBottomLeft: number]
-    | [topLeft: number, topRightAndBottomLeft: number, bottomRight: number]
+  style: {
+    dimensions?: Dimensions
+    rounded?:
+      | false
+      | number
+      | [all: number]
+      | [topLeftAndBottomRight: number, topRightAndBottomLeft: number]
+      | [topLeft: number, topRightAndBottomLeft: number, bottomRight: number]
+  }
 }
 
 /**
@@ -26,20 +28,28 @@ const Rectangle = createToken(
       id: 'Rectangle',
       props,
       defaultProps: {
-        dimensions: { width: 10, height: 10 },
-        rounded: false,
+        style: {
+          dimensions: { width: 10, height: 10 },
+          rounded: false,
+        },
       },
       path: props => {
         const path = new Path2D()
-        if (props.rounded && 'roundRect' in path)
+        if (props.style.rounded && 'roundRect' in path)
           path.roundRect(
             0,
             0,
-            props.dimensions.width,
-            props.dimensions.height,
-            props.rounded,
+            props.style.dimensions.width,
+            props.style.dimensions.height,
+            props.style.rounded,
           )
-        else path.rect(0, 0, props.dimensions.width, props.dimensions.height)
+        else
+          path.rect(
+            0,
+            0,
+            props.style.dimensions.width,
+            props.style.dimensions.height,
+          )
         return path
       },
       bounds: props => [
@@ -48,16 +58,16 @@ const Rectangle = createToken(
           y: 0,
         },
         {
-          x: props.dimensions.width,
+          x: props.style.dimensions.width,
           y: 0,
         },
         {
-          x: props.dimensions.width,
-          y: props.dimensions.height,
+          x: props.style.dimensions.width,
+          y: props.style.dimensions.height,
         },
         {
           x: 0,
-          y: props.dimensions.height,
+          y: props.style.dimensions.height,
         },
       ],
     }),

--- a/src/components/Object2D/Shape2D/Text.ts
+++ b/src/components/Object2D/Shape2D/Text.ts
@@ -47,7 +47,6 @@ const Text = createToken(
       height: 0,
     })
 
-    createEffect(() => console.log('dimensions', dimensions()))
     return createShape2D({
       id: 'Text',
       render: (props, context, matrix) => {

--- a/src/components/Object2D/Shape2D/Text.ts
+++ b/src/components/Object2D/Shape2D/Text.ts
@@ -1,5 +1,5 @@
 import { createToken } from '@solid-primitives/jsx-tokenizer'
-import { createSignal } from 'solid-js'
+import { createEffect, createSignal } from 'solid-js'
 
 import { parser } from 'src/parser'
 import {
@@ -46,6 +46,8 @@ const Text = createToken(
       width: 0,
       height: 0,
     })
+
+    createEffect(() => console.log('dimensions', dimensions()))
     return createShape2D({
       id: 'Text',
       render: (props, context, matrix) => {

--- a/src/context/InternalContext.ts
+++ b/src/context/InternalContext.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'solid-js'
 import { CanvasToken } from 'src/parser'
-import { CanvasMouseEvent, Matrix } from '../types'
+import { CanvasMouseEvent } from '../types'
 
 export type InternalContextType = {
   ctx: CanvasRenderingContext2D

--- a/src/context/InternalContext.ts
+++ b/src/context/InternalContext.ts
@@ -6,10 +6,6 @@ export type InternalContextType = {
   ctx: CanvasRenderingContext2D
   matrix: DOMMatrix
   debug: boolean
-  selected: CanvasToken | undefined
-  hovered: CanvasToken | undefined
-  isSelected: (token: CanvasToken) => boolean
-  isHovered: (token: CanvasToken) => boolean
   addEventListener: (
     type: CanvasMouseEvent['type'],
     callback: (event: CanvasMouseEvent) => void,

--- a/src/controllers/ClickStyle.ts
+++ b/src/controllers/ClickStyle.ts
@@ -14,15 +14,14 @@ const ClickStyle = createController<HoverOptions>((props, events, options) => {
   events.onMouseDown(() => setSelected(true))
   events.onMouseUp(() => setSelected(false))
 
-  return () =>
-    mergeGetters(props(), {
-      get stroke() {
-        return selected() ? options.stroke : props().stroke
-      },
-      get fill() {
-        return selected() ? options.fill : props().fill
-      },
-    })
+  return mergeGetters(props(), {
+    get stroke() {
+      return selected() ? options.stroke : props().style.stroke
+    },
+    get fill() {
+      return selected() ? options.fill : props().style.fill
+    },
+  })
 })
 
 export { ClickStyle }

--- a/src/controllers/Drag.ts
+++ b/src/controllers/Drag.ts
@@ -62,13 +62,15 @@ const Drag = createController<DragOptions>((props, events, options) => {
   events.onMouseDown(dragEventHandler)
 
   return {
-    get position() {
-      return options.controlled
-        ? props().position
-        : {
-            x: (props().position?.x || 0) + dragPosition().x,
-            y: (props().position?.y || 0) + dragPosition().y,
-          }
+    transform: {
+      get position() {
+        return options.controlled
+          ? props().transform.position
+          : {
+              x: (props().transform.position?.x || 0) + dragPosition().x,
+              y: (props().transform.position?.y || 0) + dragPosition().y,
+            }
+      },
     },
   }
 })

--- a/src/controllers/Handle/index.tsx
+++ b/src/controllers/Handle/index.tsx
@@ -42,16 +42,22 @@ const Handle = (props: {
   draggable?: boolean
   onDragMove?: (position: Vector) => void
 }) => (
-  <Group position={{ x: props.position.x - 10, y: props.position.y - 10 }}>
+  <Group
+    transform={{
+      position: { x: props.position.x - 10, y: props.position.y - 10 },
+    }}
+  >
     <Arc
-      radius={10}
-      stroke="transparent"
-      fill={props.draggable !== false ? 'black' : 'lightgrey'}
-      pointerEvents={props.draggable === false ? false : true}
-      cursor={props.draggable ? 'pointer' : 'default'}
-      hoverStyle={{
-        fill: 'white',
-        stroke: 'black',
+      style={{
+        radius: 10,
+        stroke: 'transparent',
+        fill: props.draggable !== false ? 'black' : 'lightgrey',
+        pointerEvents: props.draggable === false ? false : true,
+        cursor: props.draggable ? 'pointer' : 'default',
+        '&:hover': {
+          fill: 'white',
+          stroke: 'black',
+        },
       }}
       controllers={[
         Drag({
@@ -81,9 +87,11 @@ const VectorHandle = (props: {
     />
     <Line
       points={[{ x: 0, y: 0 }, props.position]}
-      lineDash={[10, 5]}
-      pointerEvents={false}
-      stroke={props.draggable !== false ? 'black' : 'lightgrey'}
+      style={{
+        lineDash: [10, 5],
+        pointerEvents: false,
+        stroke: props.draggable !== false ? 'black' : 'lightgrey',
+      }}
     />
   </>
 )
@@ -98,7 +106,11 @@ const BezierHandles = (props: {
   type: 'cubic' | 'quadratic'
 }) => {
   return (
-    <Group position={props.value.point}>
+    <Group
+      transform={{
+        position: props.value.point,
+      }}
+    >
       <Handle
         onDragMove={offset => props.updateOffset(offset, 'point')}
         position={{ x: 0, y: 0 }}
@@ -193,7 +205,11 @@ type HandleOptions = {
 
 const CubicHandle = createController<HandleOptions, { points: CubicPoint[] }>(
   (props, events, options) =>
-    constructBezierHandle(props, events, { ...options, type: 'cubic' }),
+    // TODO: type `constructBezierHandle` so we don't have to cast
+    constructBezierHandle(props, events, {
+      ...options,
+      type: 'cubic',
+    }) as { points: CubicPoint[] },
 )
 
 const QuadraticHandle = createController<

--- a/src/controllers/Hover.ts
+++ b/src/controllers/Hover.ts
@@ -1,0 +1,22 @@
+import { createSignal } from 'solid-js'
+import { Shape2DStyle } from 'src/types'
+import { createController } from './createController'
+
+type HoverOptions = {
+  active?: boolean
+  style: Shape2DStyle
+}
+const Hover = createController<HoverOptions>((props, events, options) => {
+  const [isHovered, setIsHovered] = createSignal(false)
+
+  events.onMouseEnter(() => setIsHovered(true))
+  events.onMouseLeave(() => setIsHovered(false))
+
+  return {
+    get style() {
+      return isHovered() ? options.style : props().style
+    },
+  }
+})
+
+export { Hover }

--- a/src/controllers/Hover.ts
+++ b/src/controllers/Hover.ts
@@ -1,4 +1,4 @@
-import { createSignal } from 'solid-js'
+import { createEffect, createSignal, mergeProps, untrack } from 'solid-js'
 import { Shape2DStyle } from 'src/types'
 import { createController } from './createController'
 
@@ -9,12 +9,17 @@ type HoverOptions = {
 const Hover = createController<HoverOptions>((props, events, options) => {
   const [isHovered, setIsHovered] = createSignal(false)
 
-  events.onMouseEnter(() => setIsHovered(true))
-  events.onMouseLeave(() => setIsHovered(false))
+  createEffect(() => {
+    if (!options.style) return
+    events.onMouseEnter(() => setIsHovered(true))
+    events.onMouseLeave(() => setIsHovered(false))
+  })
+
+  const styles = mergeProps(props().style, options.style)
 
   return {
     get style() {
-      return isHovered() ? options.style : props().style
+      return isHovered() && props().style ? styles : props().style
     },
   }
 })

--- a/src/controllers/Hover.ts
+++ b/src/controllers/Hover.ts
@@ -1,10 +1,11 @@
-import { createEffect, createSignal, mergeProps, untrack } from 'solid-js'
-import { Shape2DStyle } from 'src/types'
+import { createEffect, createSignal, mergeProps } from 'solid-js'
+import { Shape2DStyle, Transforms } from 'src/types'
 import { createController } from './createController'
 
 type HoverOptions = {
   active?: boolean
-  style: Shape2DStyle
+  style: Shape2DStyle | undefined
+  transform: Transforms | undefined
 }
 const Hover = createController<HoverOptions>((props, events, options) => {
   const [isHovered, setIsHovered] = createSignal(false)
@@ -16,10 +17,14 @@ const Hover = createController<HoverOptions>((props, events, options) => {
   })
 
   const styles = mergeProps(props().style, options.style)
+  const transforms = mergeProps(props().transform, options.transform)
 
   return {
     get style() {
-      return isHovered() && props().style ? styles : props().style
+      return isHovered() && options.style ? styles : props().style
+    },
+    get transform() {
+      return isHovered() && options.transform ? transforms : props().transform
     },
   }
 })

--- a/src/controllers/Noop.ts
+++ b/src/controllers/Noop.ts
@@ -1,5 +1,5 @@
 import { createController } from './createController'
 
-const Noop = createController(props => props)
+const Noop = createController(props => props())
 
 export { Noop }

--- a/src/controllers/controllers.ts
+++ b/src/controllers/controllers.ts
@@ -4,6 +4,7 @@ export { Drag } from './Drag'
 export { CubicHandle, QuadraticHandle } from './Handle'
 export { Noop } from './Noop'
 export { ClickStyle } from './ClickStyle'
+export { Hover } from './Hover'
 
 export type ControllerEvents = {
   [K in CanvasMouseEventTypes]: (event: CanvasMouseEvent) => void

--- a/src/controllers/createController.ts
+++ b/src/controllers/createController.ts
@@ -8,7 +8,9 @@ const createController = <
   AdditionalProperties = {},
 >(
   callback: (
-    props: Accessor<ResolvedShape2DProps & AdditionalProperties>,
+    props: Accessor<
+      ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
+    >,
     events: RegisterControllerEvents,
     options: ControllerOptions,
   ) => Partial<Shape2DProps & AdditionalProperties>,
@@ -17,18 +19,24 @@ const createController = <
     options?: ControllerOptions,
   ): Accessor<Shape2DProps<AdditionalProperties> & AdditionalProperties>
   function Controller(
-    props: Accessor<ResolvedShape2DProps & AdditionalProperties>,
+    props: Accessor<
+      ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
+    >,
     events: RegisterControllerEvents,
     options: ControllerOptions,
   ): Accessor<Shape2DProps<AdditionalProperties> & AdditionalProperties>
   function Controller(
-    propsOrOptions?: Accessor<ResolvedShape2DProps> | ControllerOptions,
+    propsOrOptions?:
+      | Accessor<ResolvedShape2DProps<AdditionalProperties>>
+      | ControllerOptions,
     events?: RegisterControllerEvents,
     options?: ControllerOptions,
   ) {
     if (!events) {
       return (
-        props: Accessor<ResolvedShape2DProps & AdditionalProperties>,
+        props: Accessor<
+          ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
+        >,
         events: RegisterControllerEvents,
       ) => Controller(props, events, propsOrOptions as ControllerOptions)
     }
@@ -36,7 +44,9 @@ const createController = <
     // NOTE:  `result` needs to be defined outside `mergeProps` for unknown reasons
 
     const result = callback(
-      propsOrOptions as Accessor<ResolvedShape2DProps & AdditionalProperties>,
+      propsOrOptions as Accessor<
+        ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
+      >,
       events,
       options!,
     )
@@ -52,7 +62,7 @@ const createController = <
       deepMergeGetters(
         (
           propsOrOptions as Accessor<
-            ResolvedShape2DProps & AdditionalProperties
+            ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
           >
         )(),
         result,

--- a/src/controllers/createController.ts
+++ b/src/controllers/createController.ts
@@ -1,6 +1,6 @@
 import { Accessor, createMemo } from 'solid-js'
 import { ResolvedShape2DProps, Shape2DProps } from 'src/types'
-import { mergeGetters } from 'src/utils/mergeGetters'
+import { deepMergeGetters, mergeGetters } from 'src/utils/mergeGetters'
 import { RegisterControllerEvents } from './controllers'
 
 const createController = <
@@ -11,7 +11,7 @@ const createController = <
     props: Accessor<ResolvedShape2DProps & AdditionalProperties>,
     events: RegisterControllerEvents,
     options: ControllerOptions,
-  ) => void,
+  ) => Partial<Shape2DProps & AdditionalProperties>,
 ) => {
   function Controller(
     options?: ControllerOptions,
@@ -49,10 +49,10 @@ const createController = <
     //         while `Object.assign` or spreading would cause a merge with each update.
 
     return createMemo(() =>
-      mergeGetters(
+      deepMergeGetters(
         (
           propsOrOptions as Accessor<
-            ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
+            ResolvedShape2DProps & AdditionalProperties
           >
         )(),
         result,

--- a/src/defaultProps.ts
+++ b/src/defaultProps.ts
@@ -1,6 +1,6 @@
 import { ResolvedShape2DProps, Shape2DProps } from 'src/types'
 
-const defaultShape2DProps: ResolvedShape2DProps = {
+const defaultShape2DProps: ResolvedShape2DProps<unknown> = {
   style: {
     stroke: 'black',
     fill: undefined,
@@ -23,7 +23,7 @@ const defaultShape2DProps: ResolvedShape2DProps = {
   },
 }
 
-const defaultBoundsProps: ResolvedShape2DProps = {
+const defaultBoundsProps: ResolvedShape2DProps<unknown> = {
   style: {
     stroke: 'grey',
     fill: 'transparent',

--- a/src/defaultProps.ts
+++ b/src/defaultProps.ts
@@ -1,42 +1,50 @@
-import { ResolvedShape2DProps } from 'src/types'
+import { ResolvedShape2DProps, Shape2DProps } from 'src/types'
 
-const defaultShape2DProps: ResolvedShape2DProps<{}> = {
-  position: { x: 0, y: 0 },
-  stroke: 'black',
-  rotation: 0,
-  fill: undefined,
-  lineDash: [],
-  lineCap: 'butt',
-  lineJoin: 'round',
-  miterLimit: 10,
-  lineWidth: 2,
-  skew: {
-    x: 0,
-    y: 0,
+const defaultShape2DProps: ResolvedShape2DProps = {
+  style: {
+    stroke: 'black',
+    fill: undefined,
+    lineDash: [],
+    lineCap: 'butt',
+    lineJoin: 'round',
+    miterLimit: 10,
+    lineWidth: 2,
+    pointerEvents: true,
+    opacity: 1,
+    cursor: 'default',
   },
-  pointerEvents: true,
-  opacity: 1,
-  cursor: undefined,
+  transform: {
+    position: { x: 0, y: 0 },
+    rotation: 0,
+    skew: {
+      x: 0,
+      y: 0,
+    },
+  },
 }
 
-const defaultBoundsProps: ResolvedShape2DProps<{}> = {
-  position: { x: 0, y: 0 },
-  stroke: 'grey',
-  rotation: 0,
-  fill: 'transparent',
-  lineDash: [],
-  lineCap: 'butt',
-  lineJoin: 'round',
-  miterLimit: 10,
-  lineWidth: 0.5,
-  skew: {
-    x: 0,
-    y: 0,
+const defaultBoundsProps: ResolvedShape2DProps = {
+  style: {
+    stroke: 'grey',
+    fill: 'transparent',
+    lineDash: [],
+    lineCap: 'butt',
+    lineJoin: 'round',
+    miterLimit: 10,
+    lineWidth: 0.5,
+    opacity: 1,
+    composite: 'destination-over',
+    cursor: undefined,
+    pointerEvents: true,
   },
-  pointerEvents: true,
-  opacity: 1,
-  composite: 'destination-over',
-  cursor: undefined,
+  transform: {
+    position: { x: 0, y: 0 },
+    rotation: 0,
+    skew: {
+      x: 0,
+      y: 0,
+    },
+  },
 }
 
 export { defaultShape2DProps, defaultBoundsProps }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export type Object2DProps = {
 }
 
 export type Shape2DProps<T = Object> = Shape2DEvents & {
-  transform?: Transforms
+  transform?: Transforms & { '&:hover'?: Transforms }
   style?: Shape2DStyle & { '&:hover'?: Shape2DStyle }
 
   /**
@@ -96,7 +96,6 @@ export interface Transforms {
   /**
    * Set transforms while hovering. Default: undefined
    */
-  '&:hover'?: Transforms
 }
 
 export interface Shape2DStyle {

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,7 @@ type Shape2DEvents = {
   onMouseLeave?: SingleOrArray<(event: CanvasMouseEvent) => void>
 }
 
-export type Transforms = {
+export interface Transforms {
   /**
    * Default: { x: 0, y: 0 }
    */
@@ -93,9 +93,13 @@ export type Transforms = {
    * Default: 0
    */
   skew?: Partial<Vector>
+  /**
+   * Set transforms while hovering. Default: undefined
+   */
+  '&:hover'?: Transforms
 }
 
-export type Shape2DStyle = {
+export interface Shape2DStyle {
   /**
    * Default: 'transparent'
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export type Shape2DProps<T = Object> = Shape2DEvents & {
   ) => T | Shape2DProps<T>)[]
 }
 
-export type ResolvedShape2DProps = {
+export type ResolvedShape2DProps<T> = Shape2DProps<T> & {
   style: RequiredPartially<
     Shape2DStyle,
     | 'stroke'

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,13 +3,152 @@ import { RegisterControllerEvents } from './controllers/controllers'
 import { CanvasToken } from './parser'
 import { RequiredPartially, SingleOrArray } from './utils/typehelpers'
 
-export type Matrix = {
-  a: number
-  b: number
-  c: number
-  d: number
-  e: number
-  f: number
+export type Object2DProps = {
+  transform?: Transforms
+  style?: {
+    composite?: Composite
+    background?: Color
+    opacity?: number
+    padding?: number
+  }
+  children?: SingleOrArray<JSX.Element>
+  clip?: Accessor<SingleOrArray<JSX.Element>>
+  // controllers?: ((props: Object2DProps, events: ControllerEvents) => any)[]
+}
+
+export type Shape2DProps<T = Object> = Shape2DEvents & {
+  transform?: Transforms
+  style?: Shape2DStyle & { '&:hover'?: Shape2DStyle }
+
+  /**
+   * Enable editable handles. Default: false
+   */
+  editable?: boolean
+
+  /**
+   * Set cursor-style when hovering
+   */
+  hoverStyle?: Shape2DStyle
+
+  children?: SingleOrArray<JSX.Element>
+  opacity?: number
+  fill?: ExtendedColor
+  composite?: Composite
+  clip?: Accessor<SingleOrArray<JSX.Element>>
+  controllers?: ((
+    props: Accessor<T | Omit<Shape2DProps, 'controllers'>>,
+    events: RegisterControllerEvents,
+  ) => T | Shape2DProps<T>)[]
+}
+
+export type ResolvedShape2DProps = {
+  style: RequiredPartially<
+    Shape2DStyle,
+    | 'stroke'
+    | 'fill'
+    | 'lineDash'
+    | 'lineCap'
+    | 'lineJoin'
+    | 'lineWidth'
+    | 'pointerEvents'
+    | 'opacity'
+    | 'cursor'
+  >
+  transform: Required<Transforms>
+}
+
+type Shape2DEvents = {
+  /**
+   * Set onMouseDown-eventhandler.
+   */
+  onMouseDown?: SingleOrArray<(event: CanvasMouseEvent) => void>
+  /**
+   * Set onMouseUp-eventhandler.
+   */
+  onMouseUp?: SingleOrArray<(event: CanvasMouseEvent) => void>
+  /**
+   * Set onMouseMove-eventhandler.
+   */
+  onMouseMove?: SingleOrArray<(event: CanvasMouseEvent) => void>
+  /**
+   * Set onMouseEnter-eventhandler.
+   */
+  onMouseEnter?: SingleOrArray<(event: CanvasMouseEvent) => void>
+  /**
+   * Set onMouseLeave-eventhandler.
+   */
+  onMouseLeave?: SingleOrArray<(event: CanvasMouseEvent) => void>
+}
+
+export type Transforms = {
+  /**
+   * Default: { x: 0, y: 0 }
+   */
+  position?: Vector
+  /**
+   * Default: { x: 0, y: 0 }
+   */
+  rotation?: number
+  /**
+   * Default: 0
+   */
+  skew?: Partial<Vector>
+}
+
+export type Shape2DStyle = {
+  /**
+   * Default: 'transparent'
+   */
+  fill?: ExtendedColor | undefined
+  /**
+   * Default: 'black'.
+   */
+  stroke?: ExtendedColor
+  /**
+   * Default: 2
+   */
+  lineWidth?: number
+  /**
+   * Default: []
+   */
+  lineDash?: number[]
+  /**
+   * Default: 'butt'
+   */
+  lineCap?: 'butt' | 'round' | 'square'
+  /**
+   * Default: 'butt'
+   */
+  lineJoin?: 'round' | 'bevel' | 'miter'
+  /**
+   * Default: 'butt'
+   */
+  miterLimit?: number
+
+  shadow?: {
+    blur?: number
+    color?: Color
+    offset?: Vector
+  }
+
+  /**
+   * Set the ctx.globalCompositeOperation. Default: source-over
+   */
+  composite?: Composite
+
+  /**
+   * Sets ctx.globalAlpha. Default: 1
+   */
+  opacity?: number
+
+  /**
+   * Set cursor-style when hovering. Default: 'default'
+   */
+  cursor?: CursorStyle
+  /**
+   * Set pointerEvents. Default: false
+   */
+  pointerEvents?: boolean
 }
 
 export type Vector = {
@@ -83,153 +222,6 @@ export type Composite =
   | 'soft-light'
   | 'difference'
   | 'exclusion'
-
-export type Object2DProps = Transforms & {
-  /**
-   * Defaults to { x: 0, y: 0}
-   */
-  position?: Vector
-  children?: SingleOrArray<JSX.Element>
-  opacity?: number
-  fill?: ExtendedColor
-  composite?: Composite
-  clip?: Accessor<SingleOrArray<JSX.Element>>
-  background?: Color
-  padding?: number
-  // controllers?: ((props: Object2DProps, events: ControllerEvents) => any)[]
-}
-
-type Shape2DEvents = {
-  /**
-   * Set onMouseDown-eventhandler.
-   */
-  onMouseDown?: SingleOrArray<(event: CanvasMouseEvent) => void>
-  /**
-   * Set onMouseUp-eventhandler.
-   */
-  onMouseUp?: SingleOrArray<(event: CanvasMouseEvent) => void>
-  /**
-   * Set onMouseMove-eventhandler.
-   */
-  onMouseMove?: SingleOrArray<(event: CanvasMouseEvent) => void>
-  /**
-   * Set onMouseEnter-eventhandler.
-   */
-  onMouseEnter?: SingleOrArray<(event: CanvasMouseEvent) => void>
-  /**
-   * Set onMouseLeave-eventhandler.
-   */
-  onMouseLeave?: SingleOrArray<(event: CanvasMouseEvent) => void>
-}
-
-export type Transforms = {
-  /**
-   * Default: { x: 0, y: 0 }
-   */
-  position?: Vector
-  /**
-   * Default: { x: 0, y: 0 }
-   */
-  rotation?: number
-  /**
-   * Default: 0
-   */
-  skew?: Partial<Vector>
-}
-
-type Shape2DStyle = {
-  /**
-   * Default: 'transparent'
-   */
-  fill?: ExtendedColor
-  /**
-   * Default: 'black'.
-   */
-  stroke?: ExtendedColor
-  /**
-   * Default: 2
-   */
-  lineWidth?: number
-  /**
-   * Default: []
-   */
-  lineDash?: number[]
-  /**
-   * Default: 'butt'
-   */
-  lineCap?: 'butt' | 'round' | 'square'
-  /**
-   * Default: 'butt'
-   */
-  lineJoin?: 'round' | 'bevel' | 'miter'
-  /**
-   * Default: 'butt'
-   */
-  miterLimit?: number
-
-  shadow?: {
-    blur?: number
-    color?: Color
-    offset?: Vector
-  }
-
-  /**
-   * Set the ctx.globalCompositeOperation. Default: source-over
-   */
-  composite?: Composite
-
-  /**
-   * Sets ctx.globalAlpha. Default: 1
-   */
-  opacity?: number
-}
-
-export type Shape2DProps<T = Object> = Transforms &
-  Shape2DStyle &
-  Shape2DEvents & {
-    /**
-     * Ignore all pointer-events. Default: false
-     */
-    pointerEvents?: boolean
-    /**
-     * Enable editable handles. Default: false
-     */
-    editable?: boolean
-
-    /**
-     * Set cursor-style when hovering
-     */
-    cursor?: CursorStyle
-
-    /**
-     * Set cursor-style when hovering
-     */
-    hoverStyle?: Shape2DStyle
-
-    children?: SingleOrArray<JSX.Element>
-    opacity?: number
-    fill?: ExtendedColor
-    composite?: Composite
-    clip?: Accessor<SingleOrArray<JSX.Element>>
-    controllers?: ((
-      props: Accessor<T | Omit<Shape2DProps, 'controllers'>>,
-      events: RegisterControllerEvents,
-    ) => T | Shape2DProps<T>)[]
-  }
-
-export type ResolvedShape2DProps<T = {}> = RequiredPartially<
-  Shape2DProps<T>,
-  | CanvasMouseEventTypes
-  | 'composite'
-  | 'fill'
-  | 'shadow'
-  | 'editable'
-  | 'cursor'
-  | 'hoverStyle'
-  | 'clip'
-  | 'children'
-  | 'controllers'
->
 
 export type CanvasMouseEventTypes =
   | 'onMouseDown'

--- a/src/utils/createControlledProps.ts
+++ b/src/utils/createControlledProps.ts
@@ -1,7 +1,8 @@
 import { createLazyMemo } from '@solid-primitives/memo'
-import { Accessor, mapArray } from 'solid-js'
-import { ControllerEvents } from 'src/controllers/controllers'
-import { Shape2DProps } from 'src/types'
+import { Accessor, createSignal, mapArray } from 'solid-js'
+import { ControllerEvents, Hover } from 'src/controllers/controllers'
+import { ResolvedShape2DProps, Shape2DProps } from 'src/types'
+import { DeepRequired } from './typehelpers'
 
 const createControlledProps = <
   T extends Record<string, any>,
@@ -43,7 +44,13 @@ const createControlledProps = <
   //@ts-ignore
   const controllers: Accessor<Accessor<T | Shape2DProps<T>>[]> = createLazyMemo(
     mapArray(
-      () => props.controllers,
+      () =>
+        props.controllers
+          ? [
+              Hover({ style: props.style?.['&:hover'] ?? {} }),
+              ...props.controllers,
+            ]
+          : [Hover({ style: props.style?.['&:hover'] ?? {} })],
       (controller, index) => {
         return controller(
           () =>
@@ -65,7 +72,7 @@ const createControlledProps = <
   return {
     get props() {
       return (controllers()[controllers().length - 1]?.() ??
-        props) as Required<U>
+        props) as ResolvedShape2DProps<U> & DeepRequired<U>
     },
     emit,
   }

--- a/src/utils/createControlledProps.ts
+++ b/src/utils/createControlledProps.ts
@@ -1,7 +1,7 @@
 import { createLazyMemo } from '@solid-primitives/memo'
 import { Accessor, mapArray } from 'solid-js'
 import { ControllerEvents } from 'src/controllers/controllers'
-import { ResolvedShape2DProps, Shape2DProps } from 'src/types'
+import { Shape2DProps } from 'src/types'
 
 const createControlledProps = <
   T extends Record<string, any>,
@@ -41,9 +41,7 @@ const createControlledProps = <
   //        It's a bit tricky to figure out.
   //        The current state is a compromise.
   //@ts-ignore
-  const controllers: Accessor<
-    Accessor<Required<U> & ResolvedShape2DProps<U>>[]
-  > = createLazyMemo(
+  const controllers: Accessor<Accessor<T | Shape2DProps<T>>[]> = createLazyMemo(
     mapArray(
       () => props.controllers,
       (controller, index) => {
@@ -66,7 +64,8 @@ const createControlledProps = <
 
   return {
     get props() {
-      return controllers()[controllers().length - 1]?.() ?? props
+      return (controllers()[controllers().length - 1]?.() ??
+        props) as Required<U>
     },
     emit,
   }

--- a/src/utils/createControlledProps.ts
+++ b/src/utils/createControlledProps.ts
@@ -47,10 +47,18 @@ const createControlledProps = <
       () =>
         props.controllers
           ? [
-              Hover({ style: props.style?.['&:hover'] ?? {} }),
+              Hover({
+                style: props.style?.['&:hover'],
+                transform: props.transform?.['&:hover'] ?? {},
+              }),
               ...props.controllers,
             ]
-          : [Hover({ style: props.style?.['&:hover'] ?? {} })],
+          : [
+              Hover({
+                style: props.style?.['&:hover'] ?? {},
+                transform: props.transform?.['&:hover'] ?? {},
+              }),
+            ],
       (controller, index) => {
         return controller(
           () =>

--- a/src/utils/createHandles.tsx
+++ b/src/utils/createHandles.tsx
@@ -33,16 +33,19 @@ const Handle = (props: {
 }) => (
   <Group>
     <Arc
-      // onDragMove={props.onDragMove}
-      radius={10}
-      stroke="transparent"
-      fill={props.draggable !== false ? 'black' : 'lightgrey'}
-      position={{ x: props.position.x - 10, y: props.position.y - 10 }}
-      pointerEvents={props.draggable === false ? false : true}
-      cursor={props.draggable ? 'pointer' : 'default'}
-      hoverStyle={{
-        fill: 'white',
-        stroke: 'black',
+      style={{
+        radius: 10,
+        stroke: 'transparent',
+        fill: props.draggable !== false ? 'black' : 'lightgrey',
+        pointerEvents: props.draggable === false ? false : true,
+        cursor: props.draggable ? 'pointer' : 'default',
+        '&:hover': {
+          fill: 'white',
+          stroke: 'black',
+        },
+      }}
+      transform={{
+        position: { x: props.position.x - 10, y: props.position.y - 10 },
       }}
       controllers={[
         Drag({ active: true, onDragMove: props.onDragMove, controlled: true }),
@@ -65,9 +68,11 @@ const VectorHandle = (props: {
     />
     <Line
       points={[{ x: 0, y: 0 }, props.position]}
-      lineDash={[10, 5]}
-      pointerEvents={false}
-      stroke={props.draggable !== false ? 'black' : 'lightgrey'}
+      style={{
+        lineDash: [10, 5],
+        pointerEvents: false,
+        stroke: props.draggable !== false ? 'black' : 'lightgrey',
+      }}
     />
   </>
 )
@@ -82,7 +87,11 @@ const BezierHandles = (props: {
   type: 'cubic' | 'quadratic'
 }) => {
   return (
-    <Group position={props.value.point}>
+    <Group
+      transform={{
+        position: props.value.point,
+      }}
+    >
       <Handle
         onDragMove={offset => props.updateOffset(offset, 'point')}
         position={{ x: 0, y: 0 }}

--- a/src/utils/createMatrix.ts
+++ b/src/utils/createMatrix.ts
@@ -1,17 +1,16 @@
-import { Accessor, createMemo, on } from 'solid-js'
+import { Accessor, createEffect, createMemo } from 'solid-js'
 import { InternalContextType } from 'src/context/InternalContext'
-import { Matrix, Shape2DProps } from 'src/types'
+import { Shape2DProps, Transforms } from 'src/types'
 
-const createMatrix = (props: Shape2DProps, context?: InternalContextType) => {
+const createMatrix = (
+  props: Accessor<{ transform?: Partial<Transforms> }>,
+  context?: InternalContextType,
+) => {
   let matrix = new DOMMatrix()
-  /* const point = new DOMPoint()
-  let offset: DOMPoint
-  const context = useInternalContext() */
 
   return createMemo(
     () => {
-      // matrix.setMatrixValue('')
-      // matrix.setMatrixValue(origin?.()?.toString() ?? '')
+      // silly, but the most performant: https://jsbench.me/6vlg41cgg8/1
       matrix.a = context?.matrix.a ?? 1
       matrix.b = context?.matrix.b ?? 0
       matrix.c = context?.matrix.c ?? 0
@@ -19,18 +18,13 @@ const createMatrix = (props: Shape2DProps, context?: InternalContextType) => {
       matrix.e = context?.matrix.e ?? 0
       matrix.f = context?.matrix.f ?? 0
 
-      matrix.translateSelf(props.position?.x, props.position?.y)
-      matrix.skewXSelf(props.skew?.x)
-      matrix.skewYSelf(props.skew?.y)
-
-      // NOTE:  skewing causes a horizontal/vertical offset
-      /* point.x = origin?.().x ?? 0
-    point.y = origin?.().y ?? 0
-    offset = point.matrixTransform(matrix)
-    matrix.translateSelf(point.x - offset.x, point.y - offset.y) */
-
-      // NOTE:  the rotation should not be included in this offset-calculation
-      matrix.rotateSelf(props.rotation)
+      matrix.translateSelf(
+        props().transform?.position?.x,
+        props().transform?.position?.y,
+      )
+      matrix.skewXSelf(props().transform?.skew?.x)
+      matrix.skewYSelf(props().transform?.skew?.y)
+      matrix.rotateSelf(props().transform?.rotation)
 
       return matrix
     },

--- a/src/utils/createMouseEventHandler.ts
+++ b/src/utils/createMouseEventHandler.ts
@@ -1,0 +1,66 @@
+import { TokenElement } from '@solid-primitives/jsx-tokenizer'
+import { Accessor } from 'solid-js'
+import { InternalContextType } from 'src/context/InternalContext'
+import { CanvasToken } from 'src/parser'
+import {
+  Vector,
+  CanvasMouseEvent,
+  CanvasMouseEventListener,
+  CanvasMouseEventTypes,
+} from 'src/types'
+import forEachReversed from './forEachReversed'
+
+const createMouseEventHandler = (
+  type: 'onMouseDown' | 'onMouseMove' | 'onMouseUp',
+  tokens: Accessor<TokenElement<CanvasToken>[]>,
+  ctx: CanvasRenderingContext2D,
+  eventListeners: Record<
+    CanvasMouseEventTypes,
+    ((event: CanvasMouseEvent) => void)[]
+  >,
+  final?: (event: CanvasMouseEvent) => void,
+) => {
+  let position: Vector
+  let delta: Vector
+  let event: CanvasMouseEvent
+  let lastCursorPosition: Vector
+
+  return (e: MouseEvent) => {
+    position = { x: e.clientX, y: e.clientY }
+    delta = lastCursorPosition
+      ? {
+          x: position.x - lastCursorPosition.x,
+          y: position.y - lastCursorPosition.y,
+        }
+      : { x: 0, y: 0 }
+    lastCursorPosition = position
+
+    // NOTE:  `event` gets mutated by `token.hitTest`
+    event = {
+      ctx,
+      position,
+      delta,
+      propagation: true,
+      target: [],
+      type,
+      cursor: 'move',
+    }
+
+    forEachReversed(tokens(), ({ data }) => {
+      if (!event.propagation) return
+      if ('hitTest' in data) {
+        data.hitTest(event)
+      }
+    })
+
+    if (event.propagation && final) final(event)
+
+    // setCursorStyle(event.cursor)
+
+    eventListeners[type].forEach(listener => listener(event))
+
+    return event
+  }
+}
+
+export { createMouseEventHandler }

--- a/src/utils/createPath2D.ts
+++ b/src/utils/createPath2D.ts
@@ -1,5 +1,5 @@
-import { Accessor, createEffect, createMemo, createSignal } from 'solid-js'
-import { defaultBoundsProps, defaultShape2DProps } from 'src/defaultProps'
+import { createMemo, createSignal } from 'solid-js'
+import { defaultShape2DProps } from 'src/defaultProps'
 import { Shape2DToken } from 'src/parser'
 import {
   CanvasMouseEventListener,
@@ -7,12 +7,10 @@ import {
   Shape2DProps,
   Vector,
 } from 'src/types'
-import { createBounds } from 'src/utils/createBounds'
 import { createControlledProps } from 'src/utils/createControlledProps'
 import { createParenthood } from 'src/utils/createParenthood'
 import renderPath from 'src/utils/renderPath'
 import { createUpdatedContext } from './createUpdatedContext'
-import { isPointInShape2D } from './isPointInShape2D'
 import { deepMergeGetters } from './mergeGetters'
 import { DeepRequired, RequireOptionals, SingleOrArray } from './typehelpers'
 

--- a/src/utils/createPath2D.ts
+++ b/src/utils/createPath2D.ts
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, mergeProps } from 'solid-js'
+import { Accessor, createEffect, createMemo, createSignal } from 'solid-js'
 import { defaultBoundsProps, defaultShape2DProps } from 'src/defaultProps'
 import { Shape2DToken } from 'src/parser'
 import {
@@ -10,19 +10,18 @@ import {
 import { createBounds } from 'src/utils/createBounds'
 import { createControlledProps } from 'src/utils/createControlledProps'
 import { createParenthood } from 'src/utils/createParenthood'
-import { mergeShape2DProps } from 'src/utils/mergeShape2DProps'
 import renderPath from 'src/utils/renderPath'
 import { createUpdatedContext } from './createUpdatedContext'
 import { isPointInShape2D } from './isPointInShape2D'
-import { deepMergeGetters, mergeGetters } from './mergeGetters'
+import { deepMergeGetters } from './mergeGetters'
 import { DeepRequired, RequireOptionals, SingleOrArray } from './typehelpers'
 
 const createPath2D = <T extends { [key: string]: any }>(arg: {
   id: string
   props: Shape2DProps<T> & T
   defaultProps: RequireOptionals<T>
-  path: (props: DeepRequired<T> & ResolvedShape2DProps) => Path2D
-  bounds: (props: DeepRequired<T> & ResolvedShape2DProps) => Vector[]
+  path: (props: DeepRequired<T> & ResolvedShape2DProps<T>) => Path2D
+  bounds: (props: DeepRequired<T> & ResolvedShape2DProps<T>) => Vector[]
 }) => {
   const props = createMemo(() =>
     deepMergeGetters(
@@ -38,38 +37,26 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
 
   const bounds = createBounds(() => arg.bounds(props()), context)
 
-  //  createEffect(() =>
-  //   console.log(
-  //     controlled.props.transform?.skew?.y,
-  //     // context.matrix,
-  //     /*  props().transform?.skew?.y,
-  //     context.matrix, */
-  //   ),
-  // )
+  const [hover, setHover] = createSignal(false)
 
   const token: Shape2DToken = {
     type: 'Shape2D',
     id: arg.id,
     path,
     render: ctx => {
-      renderPath(
-        context,
-        props(),
-        path(),
-        context.isHovered(token) || context.isSelected(token),
-      )
+      renderPath(context, controlled.props, path())
       parenthood.render(ctx)
       controlled.emit.onRender(ctx)
     },
     debug: ctx => {
-      renderPath(context, defaultBoundsProps, bounds().path, false)
+      renderPath(context, defaultBoundsProps, bounds().path)
     },
     hitTest: event => {
       parenthood.hitTest(event)
       if (!event.propagation) return false
       controlled.emit.onHitTest(event)
       if (!event.propagation) return false
-      if (controlled.props.pointerEvents === false) return false
+      if (controlled.props.style.pointerEvents === false) return false
 
       context.ctx.save()
       context.ctx.setTransform(context.matrix)
@@ -81,7 +68,10 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
         : 20
 
       const hit = isPointInShape2D(event, controlled.props, path())
+
       if (hit) {
+        event.target.push(token)
+
         let listeners = controlled.props[
           event.type
         ] as SingleOrArray<CanvasMouseEventListener>
@@ -90,9 +80,30 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
           if (Array.isArray(listeners)) listeners.forEach(l => l(event))
           else listeners(event)
         }
-        event.target.push(token)
-        if (controlled.props.cursor) event.cursor = controlled.props.cursor
+
+        if (controlled.props.cursor)
+          event.cursor = controlled.props.style.cursor
+
+        if (event.type === 'onMouseMove') {
+          if (event.target.length === 1) {
+            if (!hover()) {
+              setHover(true)
+              controlled.emit.onMouseEnter(event)
+            }
+          } else {
+            if (hover()) {
+              setHover(false)
+              controlled.emit.onMouseLeave(event)
+            }
+          }
+        }
+
         controlled.emit[event.type](event)
+      } else {
+        if (hover() && event.type === 'onMouseMove') {
+          setHover(false)
+          controlled.emit.onMouseLeave(event)
+        }
       }
       context.ctx.restore()
 

--- a/src/utils/createPath2D.ts
+++ b/src/utils/createPath2D.ts
@@ -23,6 +23,7 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
   path: (props: DeepRequired<T> & ResolvedShape2DProps<T>) => Path2D
   bounds: (props: DeepRequired<T> & ResolvedShape2DProps<T>) => Vector[]
 }) => {
+  console.log('createPath2D')
   const props = createMemo(() =>
     deepMergeGetters(
       { ...defaultShape2DProps, ...arg.defaultProps },
@@ -34,15 +35,9 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
   const context = createUpdatedContext(() => controlled.props)
   const parenthood = createParenthood(arg.props, context)
 
-  const untransformedPath = createMemo(() => arg.path(props()))
-  let p
-  const path = createMemo(() => {
-    p = new Path2D()
-    p.addPath(untransformedPath(), context.matrix)
-    return p
-  })
+  const path = createMemo(() => arg.path(props()))
 
-  const bounds = createBounds(() => arg.bounds(props()), context)
+  // const bounds = createBounds(() => arg.bounds(props()), context)
 
   const [hover, setHover] = createSignal(false)
 
@@ -56,7 +51,7 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
       controlled.emit.onRender(ctx)
     },
     debug: ctx => {
-      renderPath(context, defaultBoundsProps, bounds().path)
+      // renderPath(context, defaultBoundsProps, bounds().path)
     },
     hitTest: event => {
       parenthood.hitTest(event)
@@ -66,7 +61,7 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
       if (controlled.props.style.pointerEvents === false) return false
 
       context.ctx.save()
-      // context.ctx.setTransform(context.matrix)
+      context.ctx.setTransform(context.matrix)
 
       context.ctx.lineWidth = controlled.props.style.lineWidth
         ? controlled.props.style.lineWidth < 20
@@ -80,9 +75,10 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
         event.position.y,
       )
 
+      context.ctx.resetTransform()
+
       if (hit) {
         event.target.push(token)
-
         let listeners = controlled.props[
           event.type
         ] as SingleOrArray<CanvasMouseEventListener>

--- a/src/utils/createPath2D.ts
+++ b/src/utils/createPath2D.ts
@@ -33,7 +33,14 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
   const controlled = createControlledProps(props())
   const context = createUpdatedContext(() => controlled.props)
   const parenthood = createParenthood(arg.props, context)
-  const path = createMemo(() => arg.path(props()))
+
+  const untransformedPath = createMemo(() => arg.path(props()))
+  let p
+  const path = createMemo(() => {
+    p = new Path2D()
+    p.addPath(untransformedPath(), context.matrix)
+    return p
+  })
 
   const bounds = createBounds(() => arg.bounds(props()), context)
 
@@ -59,7 +66,7 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
       if (controlled.props.style.pointerEvents === false) return false
 
       context.ctx.save()
-      context.ctx.setTransform(context.matrix)
+      // context.ctx.setTransform(context.matrix)
 
       context.ctx.lineWidth = controlled.props.style.lineWidth
         ? controlled.props.style.lineWidth < 20
@@ -67,7 +74,11 @@ const createPath2D = <T extends { [key: string]: any }>(arg: {
           : controlled.props.style.lineWidth
         : 20
 
-      const hit = isPointInShape2D(event, controlled.props, path())
+      const hit = context.ctx.isPointInPath(
+        path(),
+        event.position.x,
+        event.position.y,
+      )
 
       if (hit) {
         event.target.push(token)

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -46,8 +46,6 @@ const createShape2D = <
   // TODO:  fix any
   arg.setup(controlled.props as any, context, matrix())
 
-  createEffect(() => console.log(arg.dimensions.width))
-
   const [shapeProps] = splitProps(arg.props, ['transform', 'style'])
   const rectangleProps = deepMergeGetters(shapeProps, {
     style: {

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -1,5 +1,5 @@
 import { TokenElement } from '@solid-primitives/jsx-tokenizer'
-import { Accessor, splitProps } from 'solid-js'
+import { Accessor, createEffect, splitProps } from 'solid-js'
 import { Rectangle } from 'src/components/Object2D/Shape2D/Path2D/Rectangle'
 import {
   InternalContextType,
@@ -11,7 +11,7 @@ import { createControlledProps } from './createControlledProps'
 import { createMatrix } from './createMatrix'
 import { createParenthood } from './createParenthood'
 import { createUpdatedContext } from './createUpdatedContext'
-import { mergeGetters } from './mergeGetters'
+import { deepMergeGetters, mergeGetters } from './mergeGetters'
 import { mergeShape2DProps } from './mergeShape2DProps'
 import withContext from './withContext'
 
@@ -38,7 +38,7 @@ const createShape2D = <
     // TODO:  fix any
     mergeShape2DProps(arg.props as any, arg.defaultValues as any),
   )
-  const matrix = createMatrix(arg.props)
+  const matrix = createMatrix(() => arg.props)
 
   const context = createUpdatedContext(() => controlled.props)
   const parenthood = createParenthood(arg.props, context)
@@ -46,19 +46,23 @@ const createShape2D = <
   // TODO:  fix any
   arg.setup(controlled.props as any, context, matrix())
 
-  const [shapeProps] = splitProps(arg.props, ['rotation', 'skew'])
-  const rectangleProps = mergeGetters(shapeProps, {
-    get dimensions() {
-      return arg.dimensions
-    },
-    get fill() {
-      return arg.props.background ?? 'black'
-    },
-    get stroke() {
-      return arg.props.background ?? 'black'
-    },
-    get lineWidth() {
-      return arg.props.padding
+  createEffect(() => console.log(arg.dimensions.width))
+
+  const [shapeProps] = splitProps(arg.props, ['transform', 'style'])
+  const rectangleProps = deepMergeGetters(shapeProps, {
+    style: {
+      get fill() {
+        return arg.props.style?.background ?? 'black'
+      },
+      get stroke() {
+        return arg.props.style?.background ?? 'black'
+      },
+      get lineWidth() {
+        return arg.props.style?.padding
+      },
+      get dimensions() {
+        return arg.dimensions
+      },
     },
   })
 

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -36,7 +36,7 @@ const createShape2D = <
 }) => {
   const controlled = createControlledProps(
     // TODO:  fix any
-    mergeShape2DProps(arg.props as any, arg.defaultValues as any),
+    deepMergeGetters(arg.defaultValues, arg.props),
   )
   const matrix = createMatrix(() => arg.props)
 

--- a/src/utils/createUpdatedContext.ts
+++ b/src/utils/createUpdatedContext.ts
@@ -1,10 +1,12 @@
 import { Accessor } from 'solid-js'
 import { useInternalContext } from 'src/context/InternalContext'
-import { Shape2DProps } from 'src/types'
+import { Shape2DProps, Transforms } from 'src/types'
 import { createMatrix } from './createMatrix'
 import { deepMergeGetters, mergeGetters } from './mergeGetters'
 
-const createUpdatedContext = (props: Accessor<Shape2DProps<any>>) => {
+const createUpdatedContext = (
+  props: Accessor<{ transform?: Partial<Transforms> }>,
+) => {
   const internalContext = useInternalContext()
   const matrix = createMatrix(props, internalContext)
   return deepMergeGetters(internalContext, {

--- a/src/utils/createUpdatedContext.ts
+++ b/src/utils/createUpdatedContext.ts
@@ -2,12 +2,12 @@ import { Accessor } from 'solid-js'
 import { useInternalContext } from 'src/context/InternalContext'
 import { Shape2DProps } from 'src/types'
 import { createMatrix } from './createMatrix'
-import { mergeGetters } from './mergeGetters'
+import { deepMergeGetters, mergeGetters } from './mergeGetters'
 
 const createUpdatedContext = (props: Accessor<Shape2DProps<any>>) => {
   const internalContext = useInternalContext()
-  const matrix = createMatrix(props(), internalContext)
-  return mergeGetters(internalContext, {
+  const matrix = createMatrix(props, internalContext)
+  return deepMergeGetters(internalContext, {
     get matrix() {
       return matrix()
     },

--- a/src/utils/isPointInShape2D.ts
+++ b/src/utils/isPointInShape2D.ts
@@ -1,25 +1,26 @@
 import {
   CanvasMouseEvent,
+  ExtendedColor,
   Object2DProps,
   ResolvedShape2DProps,
 } from 'src/types'
 
 const isPointInPath = (
   event: CanvasMouseEvent,
-  props: ResolvedShape2DProps | Object2DProps,
+  props: { style: { fill?: ExtendedColor } },
   path: Path2D,
 ) => {
   // TODO:  can not check for token.props.fill as it would re-mount ColorTokens
-  if (!props.fill) return false
+  if (!props.style.fill) return false
   return event.ctx.isPointInPath(path, event.position.x, event.position.y)
 }
 const isPointInStroke = (
   event: CanvasMouseEvent,
-  props: ResolvedShape2DProps,
+  props: { style: { fill?: ExtendedColor } },
   path: Path2D,
 ) => {
   // TODO:  can not check for props.fill as it would re-mount ColorTokens
-  if (!props.stroke) return false
+  if (!props.style.fill) return false
 
   // TODO:  we should set the strokeStyle to the path's strokeStyle
   return event.ctx.isPointInStroke(path, event.position.x, event.position.y)
@@ -27,7 +28,7 @@ const isPointInStroke = (
 
 export const isPointInShape2D = (
   event: CanvasMouseEvent,
-  props: ResolvedShape2DProps | Object2DProps,
+  props: { style: { fill?: ExtendedColor } },
   path: Path2D,
 ) => {
   const result =

--- a/src/utils/mergeGetters.ts
+++ b/src/utils/mergeGetters.ts
@@ -28,11 +28,12 @@ function deepMergeGetters<
   for (prop of [...props1, ...props2]) {
     const descriptor1 = Object.getOwnPropertyDescriptor(obj1, prop)
     const descriptor2 = Object.getOwnPropertyDescriptor(obj2, prop)
-
     if (descriptor2 && descriptor2.get) {
       Object.defineProperty(result, prop, descriptor2)
     } else if (typeof obj2[prop] === 'object') {
       result[prop] = deepMergeGetters(obj1[prop], obj2[prop])
+    } else if (obj2[prop]) {
+      result[prop] = obj2[prop]
     } else if (descriptor1 && descriptor1.get) {
       Object.defineProperty(result, prop, descriptor1)
     } else if (typeof obj1[prop] === 'object') {

--- a/src/utils/mergeGetters.ts
+++ b/src/utils/mergeGetters.ts
@@ -8,4 +8,40 @@ function mergeGetters<A, B>(a: A, b: B) {
   )
   return result as A & Omit<B, keyof A>
 }
-export { mergeGetters }
+
+function deepMergeGetters<
+  T extends { [key: string]: any },
+  U extends { [key: string]: any },
+>(obj1: T | undefined | null, obj2: U | undefined | null): T & U {
+  if (!obj1) {
+    return obj2 as T & U
+  }
+  if (!obj2) {
+    return obj1 as T & U
+  }
+
+  const result = {} as T & U
+
+  const props1 = Object.getOwnPropertyNames(obj1)
+  const props2 = Object.getOwnPropertyNames(obj2)
+  let prop: keyof T & keyof U
+  for (prop of [...props1, ...props2]) {
+    const descriptor1 = Object.getOwnPropertyDescriptor(obj1, prop)
+    const descriptor2 = Object.getOwnPropertyDescriptor(obj2, prop)
+
+    if (descriptor2 && descriptor2.get) {
+      Object.defineProperty(result, prop, descriptor2)
+    } else if (typeof obj2[prop] === 'object') {
+      result[prop] = deepMergeGetters(obj1[prop], obj2[prop])
+    } else if (descriptor1 && descriptor1.get) {
+      Object.defineProperty(result, prop, descriptor1)
+    } else if (typeof obj1[prop] === 'object') {
+      result[prop] = deepMergeGetters(obj1[prop], obj2[prop])
+    } else {
+      result[prop] = obj2[prop] !== undefined ? obj2[prop] : obj1[prop]
+    }
+  }
+
+  return result
+}
+export { mergeGetters, deepMergeGetters }

--- a/src/utils/renderPath.ts
+++ b/src/utils/renderPath.ts
@@ -6,7 +6,6 @@ export default (
   context: InternalContextType,
   props: ResolvedShape2DProps,
   path: Path2D,
-  hover: boolean | undefined,
 ) => {
   props.style.lineWidth
   context.ctx.save()
@@ -32,26 +31,6 @@ export default (
   context.ctx.setLineDash(props.style.lineDash ?? [])
 
   context.ctx.setTransform(context.matrix)
-  /* 
-  if (hover && props.hoverStyle) {
-    if (props.hoverStyle.stroke) {
-      context.ctx.strokeStyle =
-        resolveExtendedColor(props.hoverStyle.stroke) ?? context.ctx.strokeStyle
-    }
-    if (props.hoverStyle.fill) {
-      context.ctx.fillStyle =
-        resolveExtendedColor(props.hoverStyle.fill) ?? context.ctx.fillStyle
-    }
-    if (props.hoverStyle.lineWidth)
-      context.ctx.lineWidth = props.hoverStyle.lineWidth
-    if (props.hoverStyle.miterLimit)
-      context.ctx.miterLimit = props.hoverStyle.miterLimit
-    if (props.hoverStyle.lineJoin)
-      context.ctx.lineJoin = props.hoverStyle.lineJoin
-    if (props.hoverStyle.lineCap) context.ctx.lineCap = props.hoverStyle.lineCap
-    if (props.hoverStyle.lineDash)
-      context.ctx.setLineDash(props.hoverStyle.lineDash)
-  } */
 
   context.ctx.fill(path)
   context.ctx.stroke(path)

--- a/src/utils/renderPath.ts
+++ b/src/utils/renderPath.ts
@@ -4,7 +4,7 @@ import { resolveColor, resolveExtendedColor } from './resolveColor'
 
 export default (
   context: InternalContextType,
-  props: ResolvedShape2DProps,
+  props: ResolvedShape2DProps<any>,
   path: Path2D,
 ) => {
   props.style.lineWidth

--- a/src/utils/renderPath.ts
+++ b/src/utils/renderPath.ts
@@ -1,5 +1,5 @@
 import { InternalContextType } from 'src/context/InternalContext'
-import { Vector, ResolvedShape2DProps } from 'src/types'
+import { ResolvedShape2DProps } from 'src/types'
 import { resolveColor, resolveExtendedColor } from './resolveColor'
 
 export default (
@@ -8,28 +8,31 @@ export default (
   path: Path2D,
   hover: boolean | undefined,
 ) => {
+  props.style.lineWidth
   context.ctx.save()
-  if (props.shadow) {
-    context.ctx.shadowBlur = props.shadow.blur ?? 0
-    context.ctx.shadowOffsetX = props.shadow.offset?.x ?? 0
-    context.ctx.shadowOffsetY = props.shadow.offset?.y ?? 0
+  if (props.style.shadow) {
+    context.ctx.shadowBlur = props.style.shadow.blur ?? 0
+    context.ctx.shadowOffsetX = props.style.shadow.offset?.x ?? 0
+    context.ctx.shadowOffsetY = props.style.shadow.offset?.y ?? 0
     context.ctx.shadowColor =
-      resolveColor(props.shadow.color ?? 'black') ?? 'black'
+      resolveColor(props.style.shadow.color ?? 'black') ?? 'black'
   }
 
-  if (props.composite) context.ctx.globalCompositeOperation = props.composite
-  if (props.opacity) context.ctx.globalAlpha = props.opacity
+  if (props.style.composite)
+    context.ctx.globalCompositeOperation = props.style.composite
+  if (props.style.opacity) context.ctx.globalAlpha = props.style.opacity
 
-  context.ctx.strokeStyle = resolveExtendedColor(props.stroke) ?? 'black'
-  context.ctx.fillStyle = resolveExtendedColor(props.fill) ?? 'transparent'
-  context.ctx.lineWidth = props.lineWidth
-  context.ctx.miterLimit = props.miterLimit
-  context.ctx.lineJoin = props.lineJoin
-  context.ctx.lineCap = props.lineCap
-  context.ctx.setLineDash(props.lineDash)
+  context.ctx.strokeStyle = resolveExtendedColor(props.style.stroke) ?? 'black'
+  context.ctx.fillStyle =
+    resolveExtendedColor(props.style.fill) ?? 'transparent'
+  context.ctx.lineWidth = props.style.lineWidth ?? 1
+  context.ctx.miterLimit = props.style.miterLimit ?? 1
+  context.ctx.lineJoin = props.style.lineJoin ?? 'bevel'
+  context.ctx.lineCap = props.style.lineCap ?? 'round'
+  context.ctx.setLineDash(props.style.lineDash ?? [])
 
   context.ctx.setTransform(context.matrix)
-
+  /* 
   if (hover && props.hoverStyle) {
     if (props.hoverStyle.stroke) {
       context.ctx.strokeStyle =
@@ -48,7 +51,7 @@ export default (
     if (props.hoverStyle.lineCap) context.ctx.lineCap = props.hoverStyle.lineCap
     if (props.hoverStyle.lineDash)
       context.ctx.setLineDash(props.hoverStyle.lineDash)
-  }
+  } */
 
   context.ctx.fill(path)
   context.ctx.stroke(path)

--- a/src/utils/renderPath.ts
+++ b/src/utils/renderPath.ts
@@ -7,7 +7,6 @@ export default (
   props: ResolvedShape2DProps<any>,
   path: Path2D,
 ) => {
-  props.style.lineWidth
   context.ctx.save()
   if (props.style.shadow) {
     context.ctx.shadowBlur = props.style.shadow.blur ?? 0
@@ -28,9 +27,7 @@ export default (
   context.ctx.miterLimit = props.style.miterLimit ?? 1
   context.ctx.lineJoin = props.style.lineJoin ?? 'bevel'
   context.ctx.lineCap = props.style.lineCap ?? 'round'
-  context.ctx.setLineDash(props.style.lineDash ?? [])
-
-  context.ctx.setTransform(context.matrix)
+  if (props.style.lineDash) context.ctx.setLineDash(props.style.lineDash)
 
   context.ctx.fill(path)
   context.ctx.stroke(path)

--- a/src/utils/typehelpers.ts
+++ b/src/utils/typehelpers.ts
@@ -1,5 +1,7 @@
-export type RequiredPartially<T, U extends keyof T> = Required<Omit<T, U>> &
+export type RequiredPartially<T, U extends keyof T> = RequireOptionals<
   Pick<T, U>
+> &
+  Omit<T, U>
 
 export type Normalize<T> = T extends (...args: infer A) => infer R
   ? (...args: Normalize<A>) => Normalize<R>
@@ -19,8 +21,10 @@ type RemoveNever<T> = {
 /**
  * returns a type with all optional keys required and all non-optional keys as `never`
  */
-export type RequireOptionals<T extends object> = RemoveNever<
-  Required<{
-    [K in keyof T]: T extends Record<K, T[K]> ? never : T[K]
-  }>
->
+export type RequireOptionals<T extends object> = RemoveNever<{
+  [K in keyof T]: T extends Record<K, T[K]> ? never : T[K]
+}>
+
+export type DeepRequired<T> = {
+  [K in keyof T]: Required<DeepRequired<T[K]>>
+}


### PR DESCRIPTION
Introduction to `style` and `transform` prop.

A distinction is made between the two, since transform will always cascade and style won't. Maybe they will merge later on, but keeping them separate is easier to implement.

`style` contains all the `Path2DStyle` like `fill`, `stroke`, ...
`transform` contains `position` `rotation` and `skew` (should implement scale later)

`style` and `transform` (currently only style implemented) also are able to have selectors as properties, starting with `&:hover` (thanks @dev-rb for the idea)

```tsx
<Arc 
  style={{ 
    fill: "black",  
    "&:hover": {
      fill: "white"
    }
  }}
/>
```
will create an ellipse that will turn from black to white when hovering:

https://user-images.githubusercontent.com/10504064/230267485-980aaf99-a4d9-47f7-aaab-e8edb3e49bd2.mov

It's internally implemented as a controller like `Hover( { style: props.style["&:hover"] } )`. 
We could add other selectors later (like `&:isActive`) 

We (chatgpt and I) implemented `deepMergeGetters` to merge objects with possible nested getters. Merging objects like this is a lot less performant then `Object.assign` or `spread` ([see](https://perf.link/#eyJpZCI6Im04YXdpM2NieTF5IiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IHNpZ25hbEEgPSAoKSA9PiAyXG5jb25zdCBzaWduYWxCID0gKCkgPT4gMTBcblxuY29uc3Qgb2JqZWN0QSAgPSB7XG4gIGdldCBpZEEoKXtcbiAgICByZXR1cm4gc2lnbmFsQSgpXG4gIH1cbn1cbmNvbnN0IG9iamVjdEIgID0ge1xuICBnZXQgaWRCKCl7XG4gICAgcmV0dXJuIHNpZ25hbEIoKVxuICB9XG59XG4iLCJ0ZXN0cyI6W3sibmFtZSI6ImFzc2lnbiIsImNvZGUiOiJjb25zdCBhc3NpZ24gPSBPYmplY3QuYXNzaWduKHt9LCBvYmplY3RBLCBvYmplY3RCKSIsInJ1bnMiOls4OTQ1MDAsNTYwNTAwLDEwNDg1MDAsNzA5MDAwLDE4ODAwMDAsMTY3MDUwMCwxNjUyNTAwLDEzMjkwMDAsMTY1NDUwMCwyNTI4MDAwLDI0NDI1MDAsMTUwNDAwMCwxNjAyNTAwLDI1OTA1MDAsMjM3NTAwMCw5MTE1MDAsMjQ2NjUwMCwxNjcwNTAwLDE3OTg1MDAsMTYyMzUwMCwyOTA5NTAwLDEwNDgwMDAsMTEwMjUwMCwxNjcwNTAwLDE2NDMwMDAsMTQxNDUwMCwxMTMxMDAwLDE0NTU1MDAsMjg0ODUwMCwzMDY0MDAwLDI1MDMwMDAsMTIzMzAwMCwyODQyMDAwLDEyNTIwMDAsMTY2OTUwMCwyNDgzNTAwLDIzODY1MDAsMTMwMzAwMCwxNzYxMDAwLDE3NzM1MDAsMTM1NDUwMCwxMTkwNTAwLDg2MDAwMCwxOTA3MDAwLDIzOTM1MDAsMTI5OTUwMCwyOTMwNTAwLDE0NjkwMDAsNDkwMDAsODY5NTAwLDE4NjI1MDAsODI1MDAwLDI3NjY1MDAsMjUwNTAwMCwxMjgyNTAwLDExODEwMDAsMTc5MDAwMCwyNjQzMDAwLDEyOTQwMDAsMTMzMjAwMCw5Mjg1MDAsMjQ3MDAwMCwxODUxMDAwLDIxMTU1MDAsMTY3MDUwMCw5MTQ1MDAsMjc4MzUwMCwxMTYwNTAwLDE2MTY1MDAsMjc5NTAwMCwxMTk1NTAwLDI0OTMwMDAsMTUwNjUwMCwxMjA1NTAwLDE2MDk1MDAsMjI0MTUwMCwxNTQyMDAwLDI4NTMwMDAsMTYxMzAwMCwxMDQ5NTAwLDYxODAwMCwyMDY0NTAwLDE1MjcwMDAsMjgzMTUwMCw1MDkwMDAsMjAxMzAwMCwxNzU1NTAwLDE3MzQwMDAsMTY3MDUwMCwyMDc4MDAwLDE4ODAwMDAsMTIyNDUwMCwxMzk2MDAwLDEyMzUwMDAsMzIxNTAwLDE0MTM1MDAsODIzMDAwLDE2NzA1MDAsMTU2MTAwMCwxMzgyNTAwXSwib3BzIjoxNjc1MzM1fSx7Im5hbWUiOiJzcHJlYWQgdGhlbSIsImNvZGUiOiJjb25zdCBzcHJlYWQgPSB7XG4gIC4uLm9iamVjdEEsXG4gIC4uLm9iamVjdEJcbn0iLCJydW5zIjpbNDk4MDAwLDc0OTUwMCw3MDYwMDAsNDczMDAwLDE0OTM1MDAsOTY0NTAwLDExNzcwMDAsNzk3NTAwLDEyMzMwMDAsMjAwMzAwMCwxOTk4NTAwLDEzMzI1MDAsMTAxNjAwMCwyMTk0MDAwLDc0OTUwMCwxMjc0NTAwLDIzMzk1MDAsMTI1MTAwMCwxMzUxMDAwLDkxMDUwMCwyMTc3MDAwLDgyMzAwMCw4NDgwMDAsODUzMDAwLDEyNzc1MDAsNjU1MDAwLDE3Mzc1MDAsMTMyNjAwMCwyMjc4NTAwLDI0MTQwMDAsMTUzMzUwMCw3ODQ1MDAsMTk4NTUwMCw3NTA1MDAsNzEzNTAwLDgwODUwMCwyMDE0MDAwLDk0ODAwMCwxMzkwNTAwLDEyMDQ1MDAsODgwMDAwLDc4MjAwMCw2NjYwMDAsMTI0MDUwMCwxMzIzMDAwLDkwNDAwMCwyMzk4MDAwLDEwMTkwMDAsNDUwMCw1NDgwMDAsNDczMDAwLDQxMjAwMCwxMzQxMDAwLDE5NTA1MDAsNzc5MDAwLDE3NTk1MDAsMjQ4ODUwMCwxODU0NTAwLDgyNzUwMCwxMzI1MDAwLDc1MjAwMCwxMTYyNTAwLDE0MTAwMDAsMTQwNTAwMCwxNDAyNTAwLDI2MDAwMCwyMzIxNTAwLDQ3MzAwMCwxNTIwMDAwLDIyOTAwMDAsMTA1ODAwMCwyMjY5MDAwLDEwMzEwMDAsOTEyNTAwLDExNDg1MDAsMTc1NjAwMCwxMDM5NTAwLDIzODY1MDAsOTkzNTAwLDY3ODUwMCw0Mjg1MDAsMTQ5NTAwMCw5MDc1MDAsMjQ2NTAwMCwzMjcwMDAsMTYxNzUwMCw3MjA1MDAsOTkyNTAwLDEzMTYwMDAsMTQwMzUwMCwxNTI3NTAwLDk1MDUwMCwxNTI2MDAwLDI2NzQwMDAsMTc2NTAwLDc4NzAwMCwyNDk1MDAsMjMyNTUwMCw4NzgwMDAsMTA0ODAwMF0sIm9wcyI6MTI0MDk1MH0seyJuYW1lIjoiZGVmaW5lUHJvcGVydGllcyIsImNvZGUiOiJjb25zdCBkZWZpbmUgPSBPYmplY3QuZGVmaW5lUHJvcGVydGllcyhcbiAgICB7fSxcbiAgICB7XG4gICAgICAuLi5PYmplY3QuZ2V0T3duUHJvcGVydHlEZXNjcmlwdG9ycyhvYmplY3RBKSxcbiAgICAgIC4uLk9iamVjdC5nZXRPd25Qcm9wZXJ0eURlc2NyaXB0b3JzKG9iamVjdEIpLFxuICAgIH0sXG4gICkiLCJydW5zIjpbMTcyNTAwLDI5NDUwMCwyNjk1MDAsMTQ0MDAwLDUyMzAwMCwzMjMwMDAsNDYxNTAwLDM0MzUwMCw0MzM1MDAsNjE0NTAwLDcxNzUwMCw0MjY1MDAsNDE1NTAwLDczODAwMCw3MDc1MDAsMzIyNTAwLDM5MTUwMCw0MTc1MDAsNDk1MDAwLDc2OTAwMCw4NjI1MDAsMjY1NTAwLDI3NzAwMCw0MTA1MDAsOTY4NTAwLDM5MjUwMCw1NjkwMDAsNDM3NTAwLDY3MzUwMCw4NDI1MDAsNzQwMDAwLDc2NzUwMCw4NTQ1MDAsMjM1NTAwLDMyMjUwMCwyODM1MDAsNzE2MDAwLDQwMDAwMCw1MDM1MDAsNDQ5NTAwLDQ2NjAwMCwyMDI1MDAsMjgwMDAwLDU0ODAwMCw0Njk1MDAsMzAzNTAwLDcyMjAwMCwzOTgwMDAsMjk2NTAwLDE0NDAwMCwzMjQwMDAsMzAwMCw0NDkwMDAsNzY5MDAwLDY3MDAwMCw3MzU1MDAsNDU3MDAwLDY3MjUwMCwyMjM1MDAsNTQ4NTAwLDY0NDUwMCw5MzgwMDAsNDczNTAwLDk4NjAwMCw0MzM1MDAsNzE1MDAsODA5NTAwLDE0NDAwMCw1NDkwMDAsODAwMDAwLDQwNzUwMCw4MjA1MDAsNDMzNTAwLDg3NTAwMCw0MjMwMDAsNjUyNTAwLDQwOTUwMCw3NDIwMDAsMzczMDAwLDI3NTAwMCwxMjU1MDAsNTgzNTAwLDcyOTUwMCw4NTY1MDAsODkwMDAsNTc5NTAwLDIwMzUwMCw0NzY1MDAsNDg5MDAwLDk0MTUwMCw1NDkwMDAsMzc3NTAwLDI2OTUwMCw5MDcwMDAsMzIwMDAsMzE3NTAwLDQzMDAwLDcyNzUwMCw3OTk1MDAsNDA1NTAwXSwib3BzIjo0OTM5NjV9XSwidXBkYXRlZCI6IjIwMjMtMDQtMDZUMDM6NTY6MjUuNDAwWiJ9)) but it could also prevent merges from happening. We should do more performance tests to see which strategy is more beneficial.

Previous PR removed `createTransformedPath` in favor of transforming the canvas-context.
This created glitches in auto-render mode when blending layers with composite 

https://user-images.githubusercontent.com/10504064/230267148-428a03fb-5fad-4c47-82dd-5d7d0629a2f6.mp4

So it's reverted back to transforming the path instead of `ctx`