### PR TITLE
Performance-optimizations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: deploy pages
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          branch: gh-pages
+          folder: dev/dist

--- a/dev/pages/Smileys.tsx
+++ b/dev/pages/Smileys.tsx
@@ -55,7 +55,15 @@ const Smiley = (props: { counter: number }) => {
       <Group transform={{ position: { x: 0, y: 35 } }}>
         <Arc
           transform={{ position: { x: 40, y: 0 } }}
-          style={{ radius: 10, fill: 'black', stroke: false }}
+          style={{
+            radius: 10,
+            fill: 'black',
+            stroke: false,
+            pointerEvents: true,
+            '&:hover': {
+              fill: 'red',
+            },
+          }}
         />
         <Arc
           transform={{ position: { x: 80, y: 0 } }}
@@ -89,15 +97,55 @@ const App: Component = () => {
   const clock = createClock()
   clock.start()
 
+  const [amount, setAmount] = createSignal(1)
+  const [shouldUseClock, setShouldUseClock] = createSignal(false)
+
   return (
     <>
+      <div
+        style={{
+          position: 'absolute',
+          background: 'white',
+          padding: '5px',
+
+          margin: '5px',
+          'font-size': '10pt',
+          display: 'flex',
+          gap: '5px',
+          'font-family': 'monospace',
+          'flex-direction': 'column',
+        }}
+      >
+        <div style={{ display: 'flex', gap: '5px' }}>
+          <label>amount:</label>
+          <input
+            type="number"
+            style={{
+              border: 'none',
+              width: '50px',
+              'font-family': 'monospace',
+            }}
+            value={amount()}
+            onInput={e => setAmount(+e.currentTarget.value)}
+            step={10}
+          />
+        </div>
+        <div style={{ display: 'flex', gap: '5px' }}>
+          <label style={{ flex: 1 }}>clock:</label>
+          <input
+            type="checkbox"
+            checked={shouldUseClock()}
+            onInput={e => setShouldUseClock(e.currentTarget.checked)}
+          />
+        </div>
+      </div>
       <Canvas
-        clock={clock.clock()}
+        clock={shouldUseClock() ? clock.clock() : undefined}
         style={{ width: '100%', height: '100%', fill }}
         alpha
         stats
       >
-        <For each={new Array(500).fill('')}>
+        <For each={new Array(amount()).fill('')}>
           {() => <Smiley counter={clock.clock()} />}
         </For>
       </Canvas>

--- a/dev/pages/Smileys.tsx
+++ b/dev/pages/Smileys.tsx
@@ -95,9 +95,9 @@ const App: Component = () => {
   })`
 
   const clock = createClock()
-  clock.start()
+  clock.start(1000 / 30)
 
-  const [amount, setAmount] = createSignal(1)
+  const [amount, setAmount] = createSignal(300)
   const [shouldUseClock, setShouldUseClock] = createSignal(false)
 
   return (

--- a/dev/pages/rectangles.tsx
+++ b/dev/pages/rectangles.tsx
@@ -38,29 +38,29 @@ const App: Component = () => {
         draggable
       >
         <For
-          each={new Array(100).fill('').map(v => ({
-            position: {
-              x: Math.random() * (window.innerWidth + 200) - 100,
-              y: Math.random() * (window.innerHeight + 200) - 100,
+          each={new Array(600).fill('').map(v => ({
+            transform: {
+              position: {
+                x: Math.random() * (window.innerWidth + 200) - 100,
+                y: Math.random() * (window.innerHeight + 200) - 100,
+              },
+              skew: {
+                y: Math.random() * 90,
+              },
             },
-            fill: {
-              r: Math.random() * 215,
-              g: Math.random() * 215,
-              b: Math.random() * 215,
+            style: {
+              fill: {
+                r: Math.random() * 215,
+                g: Math.random() * 215,
+                b: Math.random() * 215,
+              },
+              stroke: false,
+              dimensions: { width: 100, height: 100 },
+              composite: 'hard-light' as const,
             },
-            skewY: Math.random() * 90,
           }))}
         >
-          {data => (
-            <Rectangle
-              {...data}
-              dimensions={{ width: 100, height: 100 }}
-              lineWidth={20}
-              stroke="transparent"
-              controllers={[Drag()]}
-              composite="hard-light"
-            />
-          )}
+          {data => <Rectangle {...data} controllers={[Drag()]} />}
         </For>
       </Canvas>
     </>

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "scripts": {
     "dev": "vite serve dev",
+    "dev:build": "vite build dev",
     "build": "tsup",
     "test": "concurrently pnpm:test:*",
     "test:client": "vitest",

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -310,7 +310,7 @@ export const Canvas: Component<{
 
   const mouseMoveHandler = createMouseEventHandler(
     'onMouseMove',
-    tokens,
+    interactiveTokens,
     context,
     eventListeners,
     event => {
@@ -320,7 +320,7 @@ export const Canvas: Component<{
 
   const mouseDownHandler = createMouseEventHandler(
     'onMouseDown',
-    tokens,
+    interactiveTokens,
     context,
     eventListeners,
     event => {
@@ -339,7 +339,7 @@ export const Canvas: Component<{
 
   const mouseUpHandler = createMouseEventHandler(
     'onMouseUp',
-    tokens,
+    interactiveTokens,
     context,
     eventListeners,
     event => {

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -247,10 +247,12 @@ export const Canvas: Component<{
     ctx.restore()
 
     forEachReversed(tokens(), token => {
-      if (props.debug && 'debug' in token.data) token.data.debug(ctx)
       if ('render' in token.data) token.data.render(ctx)
     })
-
+    ctx.resetTransform()
+    forEachReversed(tokens(), token => {
+      if (props.debug && 'debug' in token.data) token.data.debug(ctx)
+    })
     if (props.fill) {
       ctx.save()
       ctx.globalCompositeOperation = 'destination-over'

--- a/src/components/Object2D/Group.tsx
+++ b/src/components/Object2D/Group.tsx
@@ -1,11 +1,11 @@
 import { createToken } from '@solid-primitives/jsx-tokenizer'
 import { Accessor, mergeProps, splitProps } from 'solid-js'
 import { JSX } from 'solid-js/jsx-runtime'
+import { useInternalContext } from 'src/context/InternalContext'
 import { RegisterControllerEvents } from 'src/controllers/controllers'
 import { CanvasToken, parser } from 'src/parser'
 import { Color, Object2DProps, ResolvedShape2DProps, Vector } from 'src/types'
 import { createParenthood } from 'src/utils/createParenthood'
-import { createUpdatedContext } from 'src/utils/createUpdatedContext'
 import { SingleOrArray } from 'src/utils/typehelpers'
 import { T } from 'vitest/dist/types-c800444e'
 
@@ -37,12 +37,24 @@ const Group = createToken(parser, (props: Object2DProps) => {
   //        until then we will only allow controllers for types extending `Shape2DProps`
 
   // const controlled = createControlledProps(mergedProps)
-  const context = createUpdatedContext(() => mergedProps)
-  const parenthood = createParenthood(props, context)
+  const context = useInternalContext()
+  const parenthood = createParenthood(props, context!)
   return {
     type: 'Object2D',
     id: 'Group',
-    render: ctx => parenthood.render(ctx),
+    render: ctx => {
+      ctx.translate(
+        props.transform?.position?.x ?? 0,
+        props.transform?.position?.y ?? 0,
+      )
+      ctx.rotate(props.transform?.rotation ?? 0)
+      parenthood.render(ctx)
+      ctx.translate(
+        (props.transform?.position?.x ?? 0) * -1,
+        (props.transform?.position?.y ?? 0) * -1,
+      )
+      ctx.rotate((props.transform?.rotation ?? 0) * -1)
+    },
     debug: () => {},
     hitTest: event => {
       parenthood.hitTest(event)

--- a/src/components/Object2D/Group.tsx
+++ b/src/components/Object2D/Group.tsx
@@ -6,9 +6,7 @@ import { RegisterControllerEvents } from 'src/controllers/controllers'
 import { CanvasToken, parser } from 'src/parser'
 import { Color, Object2DProps, ResolvedShape2DProps, Vector } from 'src/types'
 import { createParenthood } from 'src/utils/createParenthood'
-import { transformedCallback } from 'src/utils/transformedCallback'
 import { SingleOrArray } from 'src/utils/typehelpers'
-import { T } from 'vitest/dist/types-c800444e'
 
 export type GroupProps = {
   children: SingleOrArray<JSX.Element>

--- a/src/components/Object2D/Group.tsx
+++ b/src/components/Object2D/Group.tsx
@@ -6,6 +6,7 @@ import { RegisterControllerEvents } from 'src/controllers/controllers'
 import { CanvasToken, parser } from 'src/parser'
 import { Color, Object2DProps, ResolvedShape2DProps, Vector } from 'src/types'
 import { createParenthood } from 'src/utils/createParenthood'
+import { transformedCallback } from 'src/utils/transformedCallback'
 import { SingleOrArray } from 'src/utils/typehelpers'
 import { T } from 'vitest/dist/types-c800444e'
 
@@ -58,22 +59,14 @@ const Group = createToken(parser, (props: Object2DProps) => {
     debug: () => {},
     hitTest: event => {
       if (!event.propagation) return
-      event.ctx.translate(
-        props.transform?.position?.x ?? 0,
-        props.transform?.position?.y ?? 0,
-      )
-      event.ctx.rotate(props.transform?.rotation ?? 0)
-      const hit = parenthood.hitTest(event)
-      if (hit) {
-        props[event.type]?.(event)
-      }
-      event.ctx.translate(
-        (props.transform?.position?.x ?? 0) * -1,
-        (props.transform?.position?.y ?? 0) * -1,
-      )
-      event.ctx.rotate((props.transform?.rotation ?? 0) * -1)
 
-      return hit
+      return transformedCallback(event.ctx, props, () => {
+        const hit = parenthood.hitTest(event)
+        if (hit) {
+          props[event.type]?.(event)
+        }
+        return hit
+      })
     },
     paths: () => [],
     tokens: [],

--- a/src/components/Object2D/Group.tsx
+++ b/src/components/Object2D/Group.tsx
@@ -57,7 +57,18 @@ const Group = createToken(parser, (props: Object2DProps) => {
     },
     debug: () => {},
     hitTest: event => {
+      event.ctx.translate(
+        props.transform?.position?.x ?? 0,
+        props.transform?.position?.y ?? 0,
+      )
+      event.ctx.rotate(props.transform?.rotation ?? 0)
       parenthood.hitTest(event)
+      event.ctx.translate(
+        (props.transform?.position?.x ?? 0) * -1,
+        (props.transform?.position?.y ?? 0) * -1,
+      )
+      event.ctx.rotate((props.transform?.rotation ?? 0) * -1)
+
       if (!event.propagation) return false
       return true
     },

--- a/src/components/Object2D/Group.tsx
+++ b/src/components/Object2D/Group.tsx
@@ -60,13 +60,11 @@ const Group = createToken(parser, (props: Object2DProps) => {
     hitTest: event => {
       if (!event.propagation) return
 
-      return transformedCallback(event.ctx, props, () => {
-        const hit = parenthood.hitTest(event)
-        if (hit) {
-          props[event.type]?.(event)
-        }
-        return hit
-      })
+      const hit = parenthood.hitTest(event)
+      if (hit) {
+        props[event.type]?.(event)
+      }
+      return hit
     },
     paths: () => [],
     tokens: [],

--- a/src/components/Object2D/Group.tsx
+++ b/src/components/Object2D/Group.tsx
@@ -57,20 +57,23 @@ const Group = createToken(parser, (props: Object2DProps) => {
     },
     debug: () => {},
     hitTest: event => {
+      if (!event.propagation) return
       event.ctx.translate(
         props.transform?.position?.x ?? 0,
         props.transform?.position?.y ?? 0,
       )
       event.ctx.rotate(props.transform?.rotation ?? 0)
-      parenthood.hitTest(event)
+      const hit = parenthood.hitTest(event)
+      if (hit) {
+        props[event.type]?.(event)
+      }
       event.ctx.translate(
         (props.transform?.position?.x ?? 0) * -1,
         (props.transform?.position?.y ?? 0) * -1,
       )
       event.ctx.rotate((props.transform?.rotation ?? 0) * -1)
 
-      if (!event.propagation) return false
-      return true
+      return hit
     },
     paths: () => [],
     tokens: [],

--- a/src/components/Object2D/Group.tsx
+++ b/src/components/Object2D/Group.tsx
@@ -56,7 +56,9 @@ const Group = createToken(parser, (props: Object2DProps) => {
       )
       ctx.rotate((props.transform?.rotation ?? 0) * -1)
     },
-    debug: () => {},
+    debug: ctx => {
+      parenthood.debug(ctx)
+    },
     hitTest: event => {
       if (!event.propagation) return
 

--- a/src/components/Object2D/Shape2D/Path2D/Line.tsx
+++ b/src/components/Object2D/Shape2D/Path2D/Line.tsx
@@ -6,7 +6,7 @@ import { createPath2D } from '../../../../utils/createPath2D'
 
 type LineProps = {
   points: Vector[]
-  style: {
+  style?: {
     close?: boolean
   }
 }
@@ -18,7 +18,9 @@ type LineProps = {
 const Line = createToken(
   parser,
   (props: Shape2DProps<LineProps> & LineProps) => {
-    let path2D: Path2D, point: Vector | undefined, index: number
+    let path2D: Path2D
+    let point: Vector | undefined
+    let index: number
     return createPath2D<LineProps>({
       id: 'Line',
       props,

--- a/src/context/InternalContext.ts
+++ b/src/context/InternalContext.ts
@@ -1,8 +1,10 @@
-import { Accessor, Setter, createContext, useContext } from 'solid-js'
+import { createContext, useContext } from 'solid-js'
 import { CanvasToken } from 'src/parser'
 import { CanvasFlags, CanvasMouseEvent } from '../types'
 
 export type InternalContextType = {
+  registerInteractiveToken: (token: CanvasToken, add?: boolean) => void
+  interactiveTokens: CanvasToken[]
   setFlag: (key: CanvasFlags, value: boolean) => void
   flags: Record<CanvasFlags, boolean>
   ctx: CanvasRenderingContext2D

--- a/src/context/InternalContext.ts
+++ b/src/context/InternalContext.ts
@@ -1,8 +1,10 @@
-import { createContext, useContext } from 'solid-js'
+import { Accessor, Setter, createContext, useContext } from 'solid-js'
 import { CanvasToken } from 'src/parser'
-import { CanvasMouseEvent } from '../types'
+import { CanvasFlags, CanvasMouseEvent } from '../types'
 
 export type InternalContextType = {
+  setFlag: (key: CanvasFlags, value: boolean) => void
+  flags: Record<CanvasFlags, boolean>
   ctx: CanvasRenderingContext2D
   matrix: DOMMatrix
   debug: boolean

--- a/src/controllers/ClickStyle.ts
+++ b/src/controllers/ClickStyle.ts
@@ -8,20 +8,22 @@ type HoverOptions = {
   stroke?: ExtendedColor
   fill?: ExtendedColor
 }
-const ClickStyle = createController<HoverOptions>((props, events, options) => {
-  const [selected, setSelected] = createSignal(false)
+const ClickStyle = createController<HoverOptions>(
+  (props, events, token, options) => {
+    const [selected, setSelected] = createSignal(false)
 
-  events.onMouseDown(() => setSelected(true))
-  events.onMouseUp(() => setSelected(false))
+    events.onMouseDown(() => setSelected(true))
+    events.onMouseUp(() => setSelected(false))
 
-  return mergeGetters(props(), {
-    get stroke() {
-      return selected() ? options.stroke : props().style.stroke
-    },
-    get fill() {
-      return selected() ? options.fill : props().style.fill
-    },
-  })
-})
+    return mergeGetters(props(), {
+      get stroke() {
+        return selected() ? options.stroke : props().style.stroke
+      },
+      get fill() {
+        return selected() ? options.fill : props().style.fill
+      },
+    })
+  },
+)
 
 export { ClickStyle }

--- a/src/controllers/Drag.ts
+++ b/src/controllers/Drag.ts
@@ -61,6 +61,9 @@ const Drag = createController<DragOptions>((props, events, options) => {
 
   events.onMouseDown(dragEventHandler)
   let position = { x: 0, y: 0 }
+
+  createEffect(() => {})
+
   return {
     transform: {
       get position() {
@@ -71,6 +74,9 @@ const Drag = createController<DragOptions>((props, events, options) => {
           return position
         }
       },
+    },
+    style: {
+      pointerEvents: true,
     },
   }
 })

--- a/src/controllers/Drag.ts
+++ b/src/controllers/Drag.ts
@@ -9,7 +9,7 @@ type DragOptions = {
   onDragMove?: (position: Vector, event: CanvasMouseEvent) => void
 }
 
-const Drag = createController<DragOptions>((props, events, options) => {
+const Drag = createController<DragOptions>((props, events, token, options) => {
   const [dragPosition, setDragPosition] = createSignal({ x: 0, y: 0 })
   const [selected, setSelected] = createSignal(false)
   const internalContext = useInternalContext()
@@ -63,6 +63,10 @@ const Drag = createController<DragOptions>((props, events, options) => {
 
   events.onMouseDown(dragEventHandler)
   let position = { x: 0, y: 0 }
+  /*  const position = createMemo(() => ({
+    x: (props().transform.position?.x || 0) + dragPosition().x,
+    y: (props().transform.position?.y || 0) + dragPosition().y
+  })) */
 
   createEffect(() => {})
 

--- a/src/controllers/Drag.ts
+++ b/src/controllers/Drag.ts
@@ -1,6 +1,6 @@
-import { Accessor, createEffect, createSignal, onCleanup } from 'solid-js'
+import { createEffect, createSignal, onCleanup } from 'solid-js'
 import { useInternalContext } from 'src/context/InternalContext'
-import { CanvasMouseEvent, Vector, Shape2DProps } from 'src/types'
+import { CanvasMouseEvent, Vector } from 'src/types'
 import { createController } from './createController'
 
 type DragOptions = {
@@ -30,6 +30,7 @@ const Drag = createController<DragOptions>((props, events, options) => {
     options.onDragMove?.(dragPosition(), event)
   }
   const handleMouseUp = (event: CanvasMouseEvent) => {
+    internalContext?.setFlag('shouldHitTest', true)
     setSelected(false)
   }
 
@@ -54,6 +55,7 @@ const Drag = createController<DragOptions>((props, events, options) => {
         ? true
         : options.active
     ) {
+      internalContext?.setFlag('shouldHitTest', false)
       setSelected(true)
       event.propagation = false
     }

--- a/src/controllers/Hover.ts
+++ b/src/controllers/Hover.ts
@@ -32,19 +32,17 @@ const Hover = createController<HoverOptions>((props, events, options) => {
     })
   })
 
-  const styles = createMemo(() => mergeProps(props().style, options.style))
-  const transforms = createMemo(() =>
-    options.transform
-      ? mergeProps(props().transform, options.transform)
-      : props().transform,
-  )
+  const mergedStyle = mergeProps(props().style, options.style)
+  const mergedTransform = mergeProps(props().transform, options.transform)
 
   return {
     get style() {
-      return options.style && isHovered() ? styles() : props().style
+      return options.style && isHovered() ? mergedStyle : props().style
     },
     get transform() {
-      return options.transform && isHovered() ? transforms() : props().transform
+      return options.transform && isHovered()
+        ? mergedTransform
+        : props().transform
     },
   }
 })

--- a/src/controllers/Hover.ts
+++ b/src/controllers/Hover.ts
@@ -1,15 +1,6 @@
-import {
-  createEffect,
-  createMemo,
-  createSignal,
-  indexArray,
-  mergeProps,
-  onCleanup,
-  untrack,
-} from 'solid-js'
-import { RGB, Shape2DStyle, Transforms } from 'src/types'
+import { createEffect, createSignal, mergeProps } from 'solid-js'
+import { Shape2DStyle, Transforms } from 'src/types'
 import { createController } from './createController'
-import { deepMergeGetters } from 'src/utils/mergeGetters'
 
 type HoverOptions = {
   active?: boolean
@@ -17,34 +8,34 @@ type HoverOptions = {
   transform: Transforms | undefined
 }
 
-const Hover = createController<HoverOptions>((props, events, options) => {
-  const [isHovered, setIsHovered] = createSignal(false)
+const Hover = createController<HoverOptions>(
+  (props, events, token, options) => {
+    const [isHovered, setIsHovered] = createSignal(false)
 
-  createEffect(() => {
-    if (!options.style) return
-    events.onMouseEnter(() => {
-      setIsHovered(true)
-      // tweens().forEach(t => t[1]('forward'))
+    createEffect(() => {
+      if (!options.style) return
+      events.onMouseEnter(() => {
+        setIsHovered(true)
+      })
+      events.onMouseLeave(() => {
+        setIsHovered(false)
+      })
     })
-    events.onMouseLeave(() => {
-      setIsHovered(false)
-      // tweens().forEach(t => t[1]('backward'))
-    })
-  })
 
-  const mergedStyle = mergeProps(props().style, options.style)
-  const mergedTransform = mergeProps(props().transform, options.transform)
+    const mergedStyle = mergeProps(props().style, options.style)
+    const mergedTransform = mergeProps(props().transform, options.transform)
 
-  return {
-    get style() {
-      return options.style && isHovered() ? mergedStyle : props().style
-    },
-    get transform() {
-      return options.transform && isHovered()
-        ? mergedTransform
-        : props().transform
-    },
-  }
-})
+    return {
+      get style() {
+        return options.style && isHovered() ? mergedStyle : props().style
+      },
+      get transform() {
+        return options.transform && isHovered()
+          ? mergedTransform
+          : props().transform
+      },
+    }
+  },
+)
 
 export { Hover }

--- a/src/controllers/createController.ts
+++ b/src/controllers/createController.ts
@@ -2,18 +2,21 @@ import { Accessor, createMemo } from 'solid-js'
 import { ResolvedShape2DProps, Shape2DProps } from 'src/types'
 import { deepMergeGetters } from 'src/utils/mergeGetters'
 import { RegisterControllerEvents } from './controllers'
+import { CanvasToken } from 'src/parser'
 
 const createController = <
   ControllerOptions extends Record<string, any>,
   AdditionalProperties = {},
+  Token = CanvasToken,
 >(
   callback: (
     props: Accessor<
       ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
     >,
     events: RegisterControllerEvents,
+    token: Accessor<Token>,
     options: ControllerOptions,
-  ) => Partial<Shape2DProps & AdditionalProperties>,
+  ) => Partial<Shape2DProps & AdditionalProperties> | undefined,
 ) => {
   function Controller(
     options?: ControllerOptions,
@@ -23,6 +26,7 @@ const createController = <
       ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
     >,
     events: RegisterControllerEvents,
+    token: Accessor<Token>,
     options: ControllerOptions,
   ): Accessor<Shape2DProps<AdditionalProperties> & AdditionalProperties>
   function Controller(
@@ -30,6 +34,7 @@ const createController = <
       | Accessor<ResolvedShape2DProps<AdditionalProperties>>
       | ControllerOptions,
     events?: RegisterControllerEvents,
+    token?: Accessor<Token>,
     options?: ControllerOptions,
   ) {
     if (!events) {
@@ -38,7 +43,8 @@ const createController = <
           ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
         >,
         events: RegisterControllerEvents,
-      ) => Controller(props, events, propsOrOptions as ControllerOptions)
+        token: Accessor<Token>,
+      ) => Controller(props, events, token, propsOrOptions as ControllerOptions)
     }
 
     // NOTE:  `result` needs to be defined outside `mergeProps` for unknown reasons
@@ -48,6 +54,7 @@ const createController = <
         ResolvedShape2DProps<AdditionalProperties> & AdditionalProperties
       >,
       events,
+      token!,
       options!,
     )
 
@@ -67,7 +74,7 @@ const createController = <
         )(),
         result,
       ),
-    ) as Accessor<Shape2DProps<AdditionalProperties> & AdditionalProperties>
+    ) as Accessor<Shape2DProps<AdditionalProperties & AdditionalProperties>>
   }
   return Controller
 }

--- a/src/defaultProps.ts
+++ b/src/defaultProps.ts
@@ -26,14 +26,15 @@ const defaultShape2DProps: ResolvedShape2DProps<unknown> = {
 const defaultBoundsProps: ResolvedShape2DProps<unknown> = {
   style: {
     stroke: 'grey',
-    fill: 'transparent',
+    // fill: 'black',
+    fill: false,
     lineDash: [],
     lineCap: 'butt',
     lineJoin: 'round',
     miterLimit: 10,
-    lineWidth: 0.5,
+    lineWidth: 2,
     opacity: 1,
-    composite: 'destination-over',
+    composite: 'source-over',
     cursor: undefined,
     pointerEvents: false,
   },

--- a/src/defaultProps.ts
+++ b/src/defaultProps.ts
@@ -9,7 +9,7 @@ const defaultShape2DProps: ResolvedShape2DProps<unknown> = {
     lineJoin: 'round',
     miterLimit: 10,
     lineWidth: 2,
-    pointerEvents: true,
+    pointerEvents: false,
     opacity: 1,
     cursor: 'default',
   },
@@ -35,7 +35,7 @@ const defaultBoundsProps: ResolvedShape2DProps<unknown> = {
     opacity: 1,
     composite: 'destination-over',
     cursor: undefined,
-    pointerEvents: true,
+    pointerEvents: false,
   },
   transform: {
     position: { x: 0, y: 0 },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,10 +1,15 @@
 import { createTokenizer, TokenElement } from '@solid-primitives/jsx-tokenizer'
 import { Accessor } from 'solid-js'
-import { CanvasMouseEvent } from './types'
+import { CanvasMouseEvent, Dimensions, Vector } from './types'
 
 export type Shape2DToken = {
   type: 'Shape2D'
   id: string
+  bounds: Accessor<{
+    path: Path2D
+    dimensions: Dimensions
+    position: Vector
+  }>
   render: (ctx: CanvasRenderingContext2D) => void
   debug: (ctx: CanvasRenderingContext2D) => void
   hitTest: (event: CanvasMouseEvent) => boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,8 @@ import { Accessor, JSX } from 'solid-js'
 import { RegisterControllerEvents } from './controllers/controllers'
 import { CanvasToken } from './parser'
 import { RequiredPartially, SingleOrArray } from './utils/typehelpers'
-import { InternalContextType } from './context/InternalContext'
 
-export type CanvasFlags = 'shouldHitTest'
+export type CanvasFlags = 'shouldHitTest' | 'hasInteractiveTokens'
 
 export type Object2DProps = CanvasMouseEvents & {
   transform?: Transforms

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ import { CanvasToken } from './parser'
 import { RequiredPartially, SingleOrArray } from './utils/typehelpers'
 import { InternalContextType } from './context/InternalContext'
 
+export type CanvasFlags = 'shouldHitTest'
+
 export type Object2DProps = {
   transform?: Transforms
   style?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import { InternalContextType } from './context/InternalContext'
 
 export type CanvasFlags = 'shouldHitTest'
 
-export type Object2DProps = {
+export type Object2DProps = CanvasMouseEvents & {
   transform?: Transforms
   style?: {
     composite?: Composite
@@ -19,7 +19,7 @@ export type Object2DProps = {
   // controllers?: ((props: Object2DProps, events: ControllerEvents) => any)[]
 }
 
-export type Shape2DProps<T = Object> = Shape2DEvents & {
+export type Shape2DProps<T = Object> = CanvasMouseEvents & {
   transform?: Transforms & { '&:hover'?: Transforms }
   style?: Shape2DStyle & { '&:hover'?: Shape2DStyle }
 
@@ -59,27 +59,27 @@ export type ResolvedShape2DProps<T> = Shape2DProps<T> & {
   transform: Required<Transforms>
 }
 
-type Shape2DEvents = {
+type CanvasMouseEvents = {
   /**
    * Set onMouseDown-eventhandler.
    */
-  onMouseDown?: SingleOrArray<(event: CanvasMouseEvent) => void>
+  onMouseDown?: (event: CanvasMouseEvent) => void
   /**
    * Set onMouseUp-eventhandler.
    */
-  onMouseUp?: SingleOrArray<(event: CanvasMouseEvent) => void>
+  onMouseUp?: (event: CanvasMouseEvent) => void
   /**
    * Set onMouseMove-eventhandler.
    */
-  onMouseMove?: SingleOrArray<(event: CanvasMouseEvent) => void>
+  onMouseMove?: (event: CanvasMouseEvent) => void
   /**
    * Set onMouseEnter-eventhandler.
    */
-  onMouseEnter?: SingleOrArray<(event: CanvasMouseEvent) => void>
+  onMouseEnter?: (event: CanvasMouseEvent) => void
   /**
    * Set onMouseLeave-eventhandler.
    */
-  onMouseLeave?: SingleOrArray<(event: CanvasMouseEvent) => void>
+  onMouseLeave?: (event: CanvasMouseEvent) => void
 }
 
 export interface Transforms {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export type Shape2DProps<T = Object> = CanvasMouseEvents & {
   controllers?: ((
     props: Accessor<T | Omit<Shape2DProps, 'controllers'>>,
     events: RegisterControllerEvents,
+    token: Accessor<CanvasToken>,
   ) => T | Shape2DProps<T>)[]
 }
 

--- a/src/utils/createBounds.ts
+++ b/src/utils/createBounds.ts
@@ -1,9 +1,8 @@
 import { Accessor, createMemo } from 'solid-js'
-import { InternalContextType } from 'src/context/InternalContext'
 
-const createBounds = (
+export const createBounds = (
   points: Accessor<{ x: number; y: number }[]>,
-  context: InternalContextType,
+  matrix: Accessor<DOMMatrix>,
 ) => {
   let dimensions: { width: number; height: number }
   let position: { x: number; y: number }
@@ -19,6 +18,7 @@ const createBounds = (
       max: -Infinity,
     },
   }
+
   return createMemo(() => {
     bounds = {
       x: {
@@ -32,11 +32,11 @@ const createBounds = (
     }
 
     points().forEach(({ x, y }) => {
-      point = new DOMPoint(x, y).matrixTransform(context.matrix)
-      if (point.x < bounds.x.min) bounds.x.min = x
-      if (point.x > bounds.x.max) bounds.x.max = x
-      if (point.y < bounds.y.min) bounds.y.min = y
-      if (point.y > bounds.y.max) bounds.y.max = y
+      point = new DOMPoint(x, y).matrixTransform(matrix())
+      if (point.x < bounds.x.min) bounds.x.min = point.x
+      if (point.x > bounds.x.max) bounds.x.max = point.x
+      if (point.y < bounds.y.min) bounds.y.min = point.y
+      if (point.y > bounds.y.max) bounds.y.max = point.y
     })
 
     dimensions = {
@@ -50,7 +50,6 @@ const createBounds = (
 
     path = new Path2D()
     path.rect(position.x, position.y, dimensions.width, dimensions.height)
-
     return {
       path,
       position,
@@ -58,5 +57,3 @@ const createBounds = (
     }
   })
 }
-
-export { createBounds }

--- a/src/utils/createControlledProps.ts
+++ b/src/utils/createControlledProps.ts
@@ -1,13 +1,8 @@
 import { createLazyMemo } from '@solid-primitives/memo'
-import { Accessor, mapArray } from 'solid-js'
+import { Accessor, createMemo, mapArray } from 'solid-js'
 import { ControllerEvents } from 'src/controllers/controllers'
 import { ResolvedShape2DProps, Shape2DProps } from 'src/types'
 import { DeepRequired } from './typehelpers'
-import withContext from './withContext'
-import {
-  InternalContext,
-  InternalContextType,
-} from 'src/context/InternalContext'
 
 const createControlledProps = <
   T extends Record<string, any>,
@@ -72,10 +67,16 @@ const createControlledProps = <
     ),
   )
 
+  const output = createMemo(
+    () =>
+      (controllers()[controllers().length - 1]?.() ??
+        props) as ResolvedShape2DProps<U> & DeepRequired<U>,
+  )
+
   return {
     get props() {
-      return (controllers()[controllers().length - 1]?.() ??
-        props) as ResolvedShape2DProps<U> & DeepRequired<U>
+      // return props
+      return output()
     },
     emit,
   }

--- a/src/utils/createControlledProps.ts
+++ b/src/utils/createControlledProps.ts
@@ -3,6 +3,7 @@ import { Accessor, createMemo, mapArray } from 'solid-js'
 import { ControllerEvents } from 'src/controllers/controllers'
 import { ResolvedShape2DProps, Shape2DProps } from 'src/types'
 import { DeepRequired } from './typehelpers'
+import { CanvasToken } from 'src/parser'
 
 const createControlledProps = <
   T extends Record<string, any>,
@@ -10,6 +11,7 @@ const createControlledProps = <
 >(
   props: U,
   defaultControllers: Accessor<T | Shape2DProps<T>>[] = [],
+  token: Accessor<CanvasToken>,
 ) => {
   const events: {
     [K in keyof ControllerEvents]: ControllerEvents[K][]
@@ -62,6 +64,7 @@ const createControlledProps = <
             onRender: callback => events.onRender.push(callback),
             onHitTest: callback => events.onHitTest.push(callback),
           },
+          token,
         )
       },
     ),

--- a/src/utils/createMouseEventHandler.ts
+++ b/src/utils/createMouseEventHandler.ts
@@ -44,7 +44,7 @@ const createMouseEventHandler = (
       type,
       cursor: 'move',
     }
-    if (context.flags.shouldHitTest) {
+    if (context.flags.shouldHitTest && context.flags.hasInteractiveTokens) {
       tokens().forEach(({ data }) => {
         if (!event.propagation) return
         if ('hitTest' in data) {

--- a/src/utils/createMouseEventHandler.ts
+++ b/src/utils/createMouseEventHandler.ts
@@ -11,7 +11,7 @@ import {
 
 const createMouseEventHandler = (
   type: 'onMouseDown' | 'onMouseMove' | 'onMouseUp',
-  tokens: Accessor<TokenElement<CanvasToken>[]>,
+  tokens: Accessor<CanvasToken[]>,
   context: InternalContextType,
   eventListeners: Record<
     CanvasMouseEventTypes,
@@ -45,7 +45,7 @@ const createMouseEventHandler = (
       cursor: 'move',
     }
     if (context.flags.shouldHitTest && context.flags.hasInteractiveTokens) {
-      tokens().forEach(({ data }) => {
+      tokens().forEach(data => {
         if (!event.propagation) return
         if ('hitTest' in data) {
           data.hitTest(event)

--- a/src/utils/createMouseEventHandler.ts
+++ b/src/utils/createMouseEventHandler.ts
@@ -8,6 +8,7 @@ import {
   CanvasMouseEventTypes,
   Vector,
 } from 'src/types'
+import { throttle } from './throttle'
 
 const createMouseEventHandler = (
   type: 'onMouseDown' | 'onMouseMove' | 'onMouseUp',
@@ -24,7 +25,7 @@ const createMouseEventHandler = (
   let event: CanvasMouseEvent
   let lastCursorPosition: Vector
 
-  return (e: MouseEvent) => {
+  const func = throttle((e: MouseEvent) => {
     position = { x: e.clientX, y: e.clientY }
     delta = lastCursorPosition
       ? {
@@ -53,14 +54,16 @@ const createMouseEventHandler = (
       })
     }
 
-    if (event.propagation && final) final(event)
+    final?.(event)
 
     // setCursorStyle(event.cursor)
 
     eventListeners[type].forEach(listener => listener(event))
 
     return event
-  }
+  })
+
+  return func
 }
 
 export { createMouseEventHandler }

--- a/src/utils/createParenthood.ts
+++ b/src/utils/createParenthood.ts
@@ -67,6 +67,9 @@ function createParenthood<T>(
     forEachReversed(tokens(), ({ data }) => {
       if ('render' in data) data.render?.(ctx)
     })
+  }
+
+  const debug = (ctx: CanvasRenderingContext2D) => {
     forEachReversed(tokens(), ({ data }) => {
       if ('debug' in data && context.debug) data.debug(ctx)
     })
@@ -85,19 +88,10 @@ function createParenthood<T>(
         }
       }
     })
-    /*  forEachReversed(tokens(), token => {
-      if (!event.propagation) return
-      if ('hitTest' in token.data) {
-        hitTestHit = token.data.hitTest(event)
-        if (hitTestHit) {
-          hitTestResult.push(token)
-        }
-      }
-    }) */
     return hitTestHit
   }
 
-  return { render, hitTest }
+  return { render, hitTest, debug }
 }
 
 export { createParenthood }

--- a/src/utils/createPath2D.ts
+++ b/src/utils/createPath2D.ts
@@ -25,7 +25,7 @@ import { useInternalContext } from 'src/context/InternalContext'
 import { createTransformedCallback } from './transformedCallback'
 import { createBounds } from './createBounds'
 
-const createPath2D = <T extends { [key: string]: any; style: any }>(arg: {
+const createPath2D = <T extends { [key: string]: any; style?: any }>(arg: {
   id: string
   props: Shape2DProps<T> & T
   defaultStyle: RequireOptionals<T['style']>

--- a/src/utils/createPath2D.ts
+++ b/src/utils/createPath2D.ts
@@ -78,6 +78,8 @@ const createPath2D = <T extends { [key: string]: any; style: any }>(arg: {
       // renderPath(context, defaultBoundsProps, bounds().path)
     },
     hitTest: event => {
+      if (!event.propagation) return false
+
       // NOTE:  we could prevent having to transform ctx
       //        if props.children.length === 0 && !style.pointerEvents;
       event.ctx.translate(
@@ -90,10 +92,7 @@ const createPath2D = <T extends { [key: string]: any; style: any }>(arg: {
 
       let hit = false
       if (controlled.props.style.pointerEvents) {
-        if (!event.propagation) return false
         controlled.emit.onHitTest(event)
-        if (!event.propagation) return false
-
         event.ctx.lineWidth = controlled.props.style.lineWidth
           ? controlled.props.style.lineWidth < 20
             ? 20
@@ -103,16 +102,10 @@ const createPath2D = <T extends { [key: string]: any; style: any }>(arg: {
         hit = isPointInShape2D(event, props, path())
 
         if (hit) {
+          event.propagation = false
           event.target.push(token)
-          let controlledListeners = controlled.props[
-            event.type
-          ] as SingleOrArray<CanvasMouseEventListener>
 
-          if (controlledListeners) {
-            if (Array.isArray(controlledListeners))
-              controlledListeners.forEach(l => l(event))
-            else controlledListeners(event)
-          }
+          controlled.props[event.type]?.(event)
 
           if (controlled.props.cursor)
             event.cursor = controlled.props.style.cursor

--- a/src/utils/createPath2D.ts
+++ b/src/utils/createPath2D.ts
@@ -1,4 +1,10 @@
-import { createMemo, createSignal, createUniqueId, mergeProps } from 'solid-js'
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  createUniqueId,
+  mergeProps,
+} from 'solid-js'
 import { defaultShape2DProps } from 'src/defaultProps'
 import { Shape2DToken } from 'src/parser'
 import {
@@ -123,6 +129,14 @@ const createPath2D = <T extends { [key: string]: any; style: any }>(arg: {
       //        if props.children.length === 0 && !style.pointerEvents;
     },
   }
+
+  createEffect(() =>
+    context?.registerInteractiveToken(
+      token,
+      controlled.props.style.pointerEvents,
+    ),
+  )
+
   return token
 }
 

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -14,7 +14,7 @@ import { createUpdatedContext } from './createUpdatedContext'
 import { deepMergeGetters, mergeGetters } from './mergeGetters'
 import { mergeShape2DProps } from './mergeShape2DProps'
 import withContext from './withContext'
-import { transformedCallback } from './transformedCallback'
+import { createTransformedCallback } from './transformedCallback'
 
 const createShape2D = <
   T,
@@ -81,6 +81,8 @@ const createShape2D = <
 
   let matrix: DOMMatrix
 
+  const transformedCallback = createTransformedCallback()
+
   const token: Object2DToken = {
     type: 'Object2D',
     id: arg.id,
@@ -100,7 +102,10 @@ const createShape2D = <
       event.ctx.resetTransform()
       return hit
     },
-    debug: event => path().data.debug(event),
+    debug: event => {
+      console.log('this happens?')
+      path().data.debug(event)
+    },
     render: ctx => {
       if (!arg.dimensions) return
 

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -79,6 +79,8 @@ const createShape2D = <
     context,
   ) as Accessor<TokenElement<Shape2DToken>>
 
+  let matrix: DOMMatrix
+
   const token: Object2DToken = {
     type: 'Object2D',
     id: arg.id,
@@ -88,15 +90,15 @@ const createShape2D = <
       if (!event.propagation) return false
       if (!arg.props.style?.pointerEvents) return false
 
-      return transformedCallback(event.ctx, arg.props, () => {
-        let hit = path().data.hitTest(event)
-        if (hit) {
-          controlled.emit[event.type](event)
-          arg.props[event.type]?.(event)
-        }
-        controlled.emit.onHitTest(event)
-        return hit
-      })
+      event.ctx.setTransform(matrix)
+      let hit = path().data.hitTest(event)
+      if (hit) {
+        controlled.emit[event.type](event)
+        arg.props[event.type]?.(event)
+      }
+      controlled.emit.onHitTest(event)
+      event.ctx.resetTransform()
+      return hit
     },
     debug: event => path().data.debug(event),
     render: ctx => {
@@ -108,6 +110,9 @@ const createShape2D = <
         arg.render(controlled.props as any, context, context.matrix)
         parenthood.render(ctx)
         controlled.emit.onRender(ctx)
+        if (arg.props.style?.pointerEvents && context.flags.shouldHitTest) {
+          matrix = ctx.getTransform()
+        }
       })
     },
   }

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -82,17 +82,16 @@ const createShape2D = <
     type: 'Object2D',
     id: arg.id,
     hitTest: event => {
+      if (!event.propagation) return false
       parenthood.hitTest(event)
       if (!event.propagation) return false
       if (!arg.props.style?.pointerEvents) return false
-
       let hit = path().data.hitTest(event)
       if (hit) {
         controlled.emit[event.type](event)
+        arg.props[event.type]?.(event)
       }
       controlled.emit.onHitTest(event)
-
-      if (!event.propagation) return false
       return hit
     },
     debug: event => path().data.debug(event),

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -96,12 +96,21 @@ const createShape2D = <
     debug: event => path().data.debug(event),
     render: ctx => {
       if (!arg.dimensions) return
-
+      ctx.translate(
+        arg.props.transform?.position?.x ?? 0,
+        arg.props.transform?.position?.y ?? 0,
+      )
+      ctx.rotate(arg.props.transform?.rotation ?? 0)
       path().data.render(ctx)
       // TODO:  fix any
       arg.render(controlled.props as any, context, context.matrix)
       parenthood.render(ctx)
       controlled.emit.onRender(ctx)
+      ctx.translate(
+        (arg.props.transform?.position?.x ?? 0) * -1,
+        (arg.props.transform?.position?.x ?? 0) * -1,
+      )
+      ctx.rotate(arg.props.transform?.rotation ?? 0)
     },
   }
   return token

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -111,6 +111,12 @@ const createShape2D = <
       })
     },
   }
+  createEffect(() =>
+    context?.registerInteractiveToken(
+      token,
+      controlled.props.style.pointerEvents,
+    ),
+  )
   return token
 }
 export { createShape2D }

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -84,12 +84,14 @@ const createShape2D = <
     hitTest: event => {
       parenthood.hitTest(event)
       if (!event.propagation) return false
-      let hit = path().data.hitTest(event)
+      if (!arg.props.style?.pointerEvents) return false
 
+      let hit = path().data.hitTest(event)
       if (hit) {
         controlled.emit[event.type](event)
       }
       controlled.emit.onHitTest(event)
+
       if (!event.propagation) return false
       return hit
     },

--- a/src/utils/createShape2D.ts
+++ b/src/utils/createShape2D.ts
@@ -36,10 +36,10 @@ const createShape2D = <
   defaultValues: U
 }) => {
   const controlled = createControlledProps(
-    // TODO:  fix any
     deepMergeGetters(arg.defaultValues, arg.props),
+    [],
+    () => token,
   )
-  // const matrix = createMatrix(() => arg.props)
 
   const context = createUpdatedContext(() => controlled.props)
   const parenthood = createParenthood(arg.props, context)
@@ -103,7 +103,6 @@ const createShape2D = <
       return hit
     },
     debug: event => {
-      console.log('this happens?')
       path().data.debug(event)
     },
     render: ctx => {

--- a/src/utils/createUpdatedContext.ts
+++ b/src/utils/createUpdatedContext.ts
@@ -8,12 +8,13 @@ const createUpdatedContext = (
   props: Accessor<{ transform?: Partial<Transforms> }>,
 ) => {
   const internalContext = useInternalContext()
-  const matrix = createMatrix(props, internalContext)
+  /* const matrix = createMatrix(props, internalContext)
   return deepMergeGetters(internalContext, {
     get matrix() {
       return matrix()
     },
-  })
+  }) */
+  return internalContext!
 }
 
 export { createUpdatedContext }

--- a/src/utils/mergeGetters.ts
+++ b/src/utils/mergeGetters.ts
@@ -26,21 +26,22 @@ function deepMergeGetters<
   props1 = Object.getOwnPropertyNames(obj1)
   props2 = Object.getOwnPropertyNames(obj2)
 
-  for (prop of [...props1, ...props2]) {
+  for (prop of [...props1, ...props2] as (keyof T & U)[]) {
     descriptor1 = Object.getOwnPropertyDescriptor(obj1, prop)
     descriptor2 = Object.getOwnPropertyDescriptor(obj2, prop)
     if (descriptor2 && descriptor2.get) {
       Object.defineProperty(result, prop, descriptor2)
-    } else if (typeof obj2[prop] === 'object') {
-      result[prop] = deepMergeGetters(obj1[prop], obj2[prop])
-    } else if (obj2[prop]) {
-      result[prop] = obj2[prop]
+    } else if (typeof obj2[prop as string] === 'object') {
+      result[prop] = deepMergeGetters(obj1[prop], obj2[prop as string])
+    } else if (obj2[prop as string]) {
+      result[prop] = obj2[prop as string]
     } else if (descriptor1 && descriptor1.get) {
       Object.defineProperty(result, prop, descriptor1)
     } else if (typeof obj1[prop] === 'object') {
-      result[prop] = deepMergeGetters(obj1[prop], obj2[prop])
+      result[prop] = deepMergeGetters(obj1[prop], obj2[prop as string])
     } else {
-      result[prop] = obj2[prop] !== undefined ? obj2[prop] : obj1[prop]
+      result[prop] =
+        obj2[prop as string] !== undefined ? obj2[prop as string] : obj1[prop]
     }
   }
 

--- a/src/utils/mergeGetters.ts
+++ b/src/utils/mergeGetters.ts
@@ -9,6 +9,8 @@ function mergeGetters<A, B>(a: A, b: B) {
   return result as A & Omit<B, keyof A>
 }
 
+// a bit unorthodox maybe, but since deepMergeGetters can run a lot, I believe it's worth it.
+let prop, props1, props2, descriptor1, descriptor2
 function deepMergeGetters<
   T extends { [key: string]: any },
   U extends { [key: string]: any },
@@ -21,13 +23,12 @@ function deepMergeGetters<
   }
 
   const result = {} as T & U
+  props1 = Object.getOwnPropertyNames(obj1)
+  props2 = Object.getOwnPropertyNames(obj2)
 
-  const props1 = Object.getOwnPropertyNames(obj1)
-  const props2 = Object.getOwnPropertyNames(obj2)
-  let prop: keyof T & keyof U
   for (prop of [...props1, ...props2]) {
-    const descriptor1 = Object.getOwnPropertyDescriptor(obj1, prop)
-    const descriptor2 = Object.getOwnPropertyDescriptor(obj2, prop)
+    descriptor1 = Object.getOwnPropertyDescriptor(obj1, prop)
+    descriptor2 = Object.getOwnPropertyDescriptor(obj2, prop)
     if (descriptor2 && descriptor2.get) {
       Object.defineProperty(result, prop, descriptor2)
     } else if (typeof obj2[prop] === 'object') {

--- a/src/utils/renderPath.ts
+++ b/src/utils/renderPath.ts
@@ -2,43 +2,40 @@ import { InternalContextType } from 'src/context/InternalContext'
 import { ResolvedShape2DProps } from 'src/types'
 import { resolveColor, resolveExtendedColor } from './resolveColor'
 
+let style
 export default (
   context: InternalContextType,
   props: ResolvedShape2DProps<any>,
   path: Path2D,
 ) => {
+  style = props.style
   context.ctx.save()
 
   // NOTE:  it would be more performant if we would compose commands from the styles with mapArray
   //        and forEach execute them, instead of doing checks on each renderPath.
 
-  if (props.style.shadow) {
-    context.ctx.shadowBlur = props.style.shadow.blur ?? 0
-    context.ctx.shadowOffsetX = props.style.shadow.offset?.x ?? 0
-    context.ctx.shadowOffsetY = props.style.shadow.offset?.y ?? 0
+  if (style.shadow) {
+    context.ctx.shadowBlur = style.shadow.blur ?? 0
+    context.ctx.shadowOffsetX = style.shadow.offset?.x ?? 0
+    context.ctx.shadowOffsetY = style.shadow.offset?.y ?? 0
     context.ctx.shadowColor =
-      resolveColor(props.style.shadow.color ?? 'black') ?? 'black'
+      resolveColor(style.shadow.color ?? 'black') ?? 'black'
   }
-  if (props.style.composite)
-    context.ctx.globalCompositeOperation = props.style.composite
-  if (props.style.opacity) context.ctx.globalAlpha = props.style.opacity
+  if (style.composite) context.ctx.globalCompositeOperation = style.composite
+  if (style.opacity) context.ctx.globalAlpha = style.opacity
 
-  if (props.style.fill) {
-    context.ctx.fillStyle =
-      resolveExtendedColor(props.style.fill) ?? 'transparent'
+  if (style.fill) {
+    context.ctx.fillStyle = resolveExtendedColor(style.fill) ?? 'transparent'
     context.ctx.fill(path)
   }
-  if (props.style.stroke && props.style.stroke !== 'transparent') {
-    if (props.style.lineWidth) context.ctx.lineWidth = props.style.lineWidth
-    if (props.style.miterLimit) context.ctx.miterLimit = props.style.miterLimit
-    if (props.style.lineJoin)
-      context.ctx.lineJoin = props.style.lineJoin ?? 'bevel'
-    if (context.ctx.lineCap)
-      context.ctx.lineCap = props.style.lineCap ?? 'round'
-    if (props.style.lineDash) context.ctx.setLineDash(props.style.lineDash)
+  if (style.stroke && style.stroke !== 'transparent') {
+    if (style.lineWidth) context.ctx.lineWidth = style.lineWidth
+    if (style.miterLimit) context.ctx.miterLimit = style.miterLimit
+    if (style.lineJoin) context.ctx.lineJoin = style.lineJoin ?? 'bevel'
+    if (context.ctx.lineCap) context.ctx.lineCap = style.lineCap ?? 'round'
+    if (style.lineDash) context.ctx.setLineDash(style.lineDash)
 
-    context.ctx.strokeStyle =
-      resolveExtendedColor(props.style.stroke) ?? 'black'
+    context.ctx.strokeStyle = resolveExtendedColor(style.stroke) ?? 'black'
     context.ctx.stroke(path)
   }
 

--- a/src/utils/renderPath.ts
+++ b/src/utils/renderPath.ts
@@ -19,11 +19,10 @@ export default (
     context.ctx.shadowColor =
       resolveColor(props.style.shadow.color ?? 'black') ?? 'black'
   }
-  // if (props.style.composite)
-  context.ctx.globalCompositeOperation = props.style.composite ?? 'source-over'
+  if (props.style.composite)
+    context.ctx.globalCompositeOperation = props.style.composite
   if (props.style.opacity) context.ctx.globalAlpha = props.style.opacity
 
-  context.ctx.setTransform(context.matrix)
   if (props.style.fill) {
     context.ctx.fillStyle =
       resolveExtendedColor(props.style.fill) ?? 'transparent'
@@ -36,13 +35,12 @@ export default (
       context.ctx.lineJoin = props.style.lineJoin ?? 'bevel'
     if (context.ctx.lineCap)
       context.ctx.lineCap = props.style.lineCap ?? 'round'
-    // if (props.style.lineDash) context.ctx.setLineDash(props.style.lineDash)
+    if (props.style.lineDash) context.ctx.setLineDash(props.style.lineDash)
 
     context.ctx.strokeStyle =
       resolveExtendedColor(props.style.stroke) ?? 'black'
     context.ctx.stroke(path)
   }
-  context.ctx.resetTransform()
 
   context.ctx.restore()
 }

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,0 +1,14 @@
+let amount = 60
+export const throttle = (callback: (...args: any[]) => void) => {
+  let lastTime: number = performance.now()
+  return (...args: any[]) => {
+    if (performance.now() - lastTime < 1000 / amount) {
+      lastTime = performance.now()
+      queueMicrotask(() => callback(...args))
+      return
+    } else {
+      lastTime = performance.now()
+      return callback(...args)
+    }
+  }
+}

--- a/src/utils/transformedCallback.ts
+++ b/src/utils/transformedCallback.ts
@@ -1,0 +1,44 @@
+import { Transforms } from 'src/types'
+
+let matrix: DOMMatrix, matrix2: DOMMatrix, result: any
+
+const transformedCallback = <T>(
+  ctx: CanvasRenderingContext2D,
+  props: { transform?: Transforms },
+  callback: () => T,
+): T => {
+  if (!props.transform) {
+    return callback()
+  } else if (props.transform.skew) {
+    matrix = ctx.getTransform()
+    matrix2 = ctx.getTransform()
+    matrix.translateSelf(
+      props.transform.position?.x ?? 0,
+      props.transform.position?.y ?? 0,
+    )
+    matrix.rotateSelf(props.transform.rotation ?? 0)
+    matrix.skewXSelf(props.transform.skew?.x ?? 0)
+    matrix.skewYSelf(props.transform.skew?.y ?? 0)
+    ctx.setTransform(matrix)
+    result = callback()
+    ctx.setTransform(matrix2)
+    return result
+  } else {
+    ctx.translate(
+      props.transform.position?.x ?? 0,
+      props.transform.position?.y ?? 0,
+    )
+    ctx.rotate(props.transform.rotation ?? 0)
+
+    result = callback()
+
+    ctx.translate(
+      (props.transform.position?.x ?? 0) * -1,
+      (props.transform.position?.y ?? 0) * -1,
+    )
+    ctx.rotate((props.transform.rotation ?? 0) * -1)
+    return result
+  }
+}
+
+export { transformedCallback }


### PR DESCRIPTION
Further performance-optimizations.
Test-scene is now [Smileys](https://github.com/bigmistqke/solid-canvas/blob/performance/dev/pages/Smileys.tsx), which has no blending-modes, but a more complicated structure (parent-siblings).

Optimizations include:
- cascading transforms by rotating/translating the context before (and perform the inverse transformation after) render/hitTest  instead of calculating DOMMatrix for each node seperately¹ .
- default `style.pointerEvents` is now false, to prevent unnecessary hitTests. I was toying with the idea of `Drag` and `Hover` to set the `style` automatically, but decided against it. `Drag` and `Hover` with `style.pointerEvents === false` is now a no-op.
- introduce `internalContext.flags`:  controllers now can set flags. first use-case is `Drag` and `flags.shouldHitTest`: while dragging it sets `flag.shouldHitTest` to false, preventing jank while dragging².
- a +/- 5% was spent in `createLazyMemo` of `createControlledProps`: this result is now memo-ed instead.
- fix: `Drag` and `Hover` were merging style-props with each update, this is now done during initialization.

results experiment (ios m2 firefox, Smileys.tsx with 600 instances)

before 

<img width="1440" alt="Screenshot 2023-04-08 at 20 52 29" src="https://user-images.githubusercontent.com/10504064/230738159-78ff63cb-2248-4a14-986b-5e9e118db79f.png">

after 

<img width="1440" alt="Screenshot 2023-04-08 at 20 53 31" src="https://user-images.githubusercontent.com/10504064/230738198-55df3c1d-807f-4f38-ae4b-25050a5896b1.png">

The part without red is when dragging, before and after are when hovering with the mouse. The hitTests clearly still have room for improvement.

¹ *this does not account for skewing/scaling. ideally we should `setTransform` and calculate the matrix-values ourselves. This could possibly negate all performance-benefits, but then we could default to translate/rotate in case scale/skew no-ops*
² *It's a bit buggy atm: if you accidentally hover over something else just before you dragged that element will stay in that hover-style during the drag. Possible solution would be to introduce back the idea of having a `focused`, `hovered` and `active` element and checking for that inside `Hover`. This might even eliminate the idea of `flags` in favor of checking for the active element with a selector.*